### PR TITLE
Fix initialization of Foundation

### DIFF
--- a/bbpress/loop-replies.php
+++ b/bbpress/loop-replies.php
@@ -197,5 +197,8 @@
 	}
 	?>
 </div>
-
+<script> 
+	jQuery(document).foundation();
+</script>
+ 
 <?php do_action( 'bbp_template_after_replies_loop' ); ?>

--- a/buddypress/common/filters/directory-filters.php
+++ b/buddypress/common/filters/directory-filters.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * BP Nouveau Component's directory filters template.
+ *
+ * @since BuddyPress 3.0.0
+ * @version 3.0.0
+ */
+?>
+
+<?php
+if ( bp_current_component() === 'activity' ) {
+	return '';
+}
+?>
+
+
+<div id="dir-filters" class="component-filters clearfix">
+	
+	<div id="<?php bp_nouveau_filter_container_id(); ?>" class="last filter">
+		<label class="bp-screen-reader-text" for="<?php bp_nouveau_filter_id(); ?>">
+			<span ><?php bp_nouveau_filter_label(); ?></span>
+		</label>
+		<div class="select-wrap">
+			<select id="<?php bp_nouveau_filter_id(); ?>" data-bp-filter="<?php bp_nouveau_filter_component(); ?>">
+
+				<?php bp_nouveau_filter_options(); ?>
+
+			</select>
+			<span class="select-arrow" aria-hidden="true"></span>
+		</div>
+	</div>
+</div>

--- a/buddypress/common/filters/grid-filters.php
+++ b/buddypress/common/filters/grid-filters.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * BP Nouveau Component's grid filters template.
+ *
+ * @since BuddyBoss 1.0.0
+ */
+
+global $post;
+
+if ( bp_is_members_directory() || bp_is_user() || ( is_a( $post, 'WP_Post' ) && has_shortcode( $post->post_content, 'profile' ) ) || bp_is_group_members() ) {
+	if ( ! bp_is_user_groups() ) {
+		$current_value = bp_get_option( 'bp-profile-layout-format', 'list_grid' );
+	} else {
+		$current_value = bp_get_option( 'bp-group-layout-format', 'list_grid' );
+	}
+} elseif ( bp_is_groups_directory() || bp_is_group() || ( is_a( $post, 'WP_Post' ) && has_shortcode( $post->post_content, 'group' ) ) ) {
+	$current_value = bp_get_option( 'bp-group-layout-format', 'list_grid' );
+} else {
+	$current_value = bp_get_option( 'bp-group-layout-format', 'list_grid' );
+}
+if ( 'list_grid' === $current_value ) {
+
+
+	$list                  = false;
+	$default_current_value = '';
+	if ( isset( $_POST['extras'] ) && ! empty( $_POST['extras']['layout'] ) && 'list' === $_POST['extras']['layout'] ) {
+		$list                  = true;
+		$default_current_value = 'list';
+	}
+
+	if ( ! $list ) {
+		if ( bp_is_members_directory() || bp_is_user() || ( is_a( $post, 'WP_Post' ) && has_shortcode( $post->post_content, 'profile' ) ) ) {
+			if ( ! bp_is_user_groups() ) {
+				$default_current_value = bp_profile_layout_default_format( 'grid' );
+			} else {
+				$default_current_value = bp_group_layout_default_format( 'grid' );
+			}
+		} elseif ( bp_is_groups_directory() || bp_is_group() || ( is_a( $post, 'WP_Post' ) && has_shortcode( $post->post_content, 'group' ) ) ) {
+			if ( ! bp_is_user_groups() && ! bp_is_groups_directory() ) {
+				$default_current_value = bp_profile_layout_default_format( 'grid' );
+			} else {
+				$default_current_value = bp_group_layout_default_format( 'grid' );
+			}
+		} else {
+			$default_current_value = bp_group_layout_default_format( 'grid' );
+		}
+	}
+	$component = bp_current_component();
+	if ( bp_is_group() && 'members' === bp_current_action() ) {
+		$component = 'group_members';
+	}
+	?>
+<div class="grid-filters" data-object="<?php echo esc_attr( $component ); ?>">
+	<a href="#" class="layout-view layout-grid-view bp-tooltip <?php echo ( 'grid' === $default_current_value ) ? 'active' : ''; ?>" data-view="grid" data-bp-tooltip-pos="up" data-bp-tooltip="
+																		  <?php
+																			_e(
+																				'Grid View',
+																				'buddyboss'
+																			);
+																			?>
+		"> <i class="bb-icon-grid-view-small" aria-hidden="true"></i> </a>
+
+	<a href="#" class="layout-view layout-list-view bp-tooltip <?php echo ( 'list' === $default_current_value ) ? 'active' : ''; ?>" data-view="list" data-bp-tooltip-pos="up" data-bp-tooltip="
+																		  <?php
+																			_e(
+																				'List View',
+																				'buddyboss'
+																			);
+																			?>
+		"> <i class="bb-icon-list-view-small" aria-hidden="true"></i> </a>
+	</div>
+	<?php
+}

--- a/buddypress/common/filters/group-filters.php
+++ b/buddypress/common/filters/group-filters.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * BP Nouveau Component's groups filters template.
+ *
+ * @since BuddyBoss 1.0.0
+ */
+
+// Check group type enable?
+if ( false === bp_disable_group_type_creation() ) {
+	return '';
+}
+
+// No need to show the group type select dropdown.
+$group_type = bp_get_current_group_directory_type();
+if ( ! empty( $group_type ) ) {
+	return '';
+}
+
+
+$args = array(
+	'meta_query' => array(
+		array(
+			'key'   => '_bp_group_type_enable_filter',
+			'value' => 1,
+		),
+	)
+);
+
+// Get active group types.
+if ( bp_is_groups_directory() ) {
+	$args['meta_query'][] = array(
+		'key'   => '_bp_group_type_enable_remove',
+		'value' => 0,
+	);
+}
+
+$group_types = bp_get_active_group_types( $args );
+
+if ( ! empty( $group_types ) ) {
+	?>
+	<div id="group-type-filters" class="component-filters clearfix">
+		<div id="group-type-select" class="last filter">
+			<label class="bp-screen-reader-text" for="group-type-order-by">
+				<span><?php bp_nouveau_filter_label(); ?></span>
+			</label>
+			<div class="select-wrap">
+				<select id="group-type-order-by"
+				        data-bp-group-type-filter="<?php bp_nouveau_search_object_data_attr() ?>">
+					<option value=""><?php _e( 'All Types', 'buddyboss' ); ?></option><?php
+					foreach ( $group_types as $group_type_id ) {
+						$group_type_key   = bp_group_get_group_type_key( $group_type_id );
+						$group_type_label = bp_groups_get_group_type_object( $group_type_key )->labels['name'];
+						?>
+						<option
+						value="<?php echo esc_attr( $group_type_key ); ?>"><?php echo esc_attr( $group_type_label ); ?></option><?php
+					}
+					?>
+				</select>
+				<span class="select-arrow" aria-hidden="true"></span>
+			</div>
+		</div>
+	</div>
+	<?php
+}

--- a/buddypress/common/filters/member-filters.php
+++ b/buddypress/common/filters/member-filters.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * BP Nouveau Component's members filters template.
+ *
+ * @since BuddyBoss 1.0.0
+ */
+
+// Check profile type enable?
+$is_member_type_enabled = bp_member_type_enable_disable();
+
+if ( false === $is_member_type_enabled ) {
+	return '';
+}
+
+$args = array(
+	'meta_query' => array(
+		array(
+			'key'   => '_bp_member_type_enable_filter',
+			'value' => 1,
+		),
+	)
+);
+
+if ( bp_is_members_directory() ) {
+	$args['meta_query'][] = array(
+		'key'   => '_bp_member_type_enable_remove',
+		'value' => 0,
+	);
+}
+
+// Get active member types
+$member_types = bp_get_active_member_types( $args );
+
+if ( ! empty( $member_types ) ) {
+	?>
+	<div id="member-type-filters" class="component-filters clearfix">
+		<div id="member-type-select" class="last filter">
+			<label class="bp-screen-reader-text" for="member-type-order-by">
+				<span><?php bp_nouveau_filter_label(); ?></span>
+			</label>
+			<div class="select-wrap">
+				<select id="member-type-order-by" data-bp-member-type-filter="members">
+					<option value=""><?php _e( 'All Types', 'buddyboss' ); ?></option><?php
+					foreach ( $member_types as $member_type_id ) {
+						$type_name        = bp_get_member_type_key( $member_type_id );
+						$member_type_name = get_post_meta( $member_type_id, '_bp_member_type_label_singular_name', true );
+						?>
+						<option value="<?php echo esc_attr( $member_type_id ); ?>">
+							<?php echo esc_attr( $member_type_name ); ?>
+						</option>
+						<?php
+					}
+					?>
+				</select>
+				<span class="select-arrow" aria-hidden="true"></span>
+			</div>
+		</div>
+	</div>
+	<?php
+}

--- a/buddypress/common/js-templates/activity/comments.php
+++ b/buddypress/common/js-templates/activity/comments.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Activity Comments JS Templates
+ *
+ * @version BuddyBoss 1.0.0
+ */
+?>
+<script type="text/html" id="tmpl-activity-comments-loading-message">
+	<div id="bp-activity-comments-ajax-loader"><?php bp_nouveau_user_feedback( 'activity-comments-loading' ); ?></div>
+</script>

--- a/buddypress/common/js-templates/activity/form.php
+++ b/buddypress/common/js-templates/activity/form.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Activity Post form JS Templates
+ *
+ * @version 3.1.0
+ */
+
+/**
+ * Split each js template to its own file. Easier for child theme to
+ * overwrite individual parts.
+ *
+ * @version Buddyboss 1.0.0
+ */
+$template_parts = apply_filters(
+	'bp_messages_js_template_parts',
+	array(
+		'parts/bp-activity-attached-gif',
+		'parts/bp-activity-link-preview',
+		'parts/bp-activity-media',
+		'parts/bp-activity-document',
+		'parts/bp-activity-post-form-avatar',
+		'parts/bp-activity-post-form-buttons',
+		'parts/bp-activity-post-form-feedback',
+		'parts/bp-activity-post-form-options',
+		'parts/bp-activity-target-item',
+		'parts/bp-gif-media-search-dropdown',
+		'parts/bp-gif-result-item',
+		'parts/bp-whats-new-toolbar',
+		'parts/bp-activity-post-form-privacy',
+		'parts/bp-activity-edit-postin',
+	)
+);
+
+foreach ( $template_parts as $template_part ) {
+	bp_get_template_part( 'common/js-templates/activity/' . $template_part );
+}

--- a/buddypress/common/js-templates/activity/parts/bp-activity-attached-gif.php
+++ b/buddypress/common/js-templates/activity/parts/bp-activity-attached-gif.php
@@ -1,0 +1,10 @@
+<script type="text/html" id="tmpl-activity-attached-gif">
+	<# if ( ! _.isUndefined( data.gif_data.images ) ) { #>
+	<div class="gif-image-container">
+		<img src="{{data.gif_data.images.original.url}}" alt="">
+	</div>
+	<div class="gif-image-remove gif-image-overlay">
+		<i class="bb-icon-close"></i>
+	</div>
+	<# } #>
+</script>

--- a/buddypress/common/js-templates/activity/parts/bp-activity-document.php
+++ b/buddypress/common/js-templates/activity/parts/bp-activity-document.php
@@ -1,0 +1,3 @@
+<script type="text/html" id="tmpl-activity-document">
+	<div class="dropzone closed" id="activity-post-document-uploader"></div>
+</script>

--- a/buddypress/common/js-templates/activity/parts/bp-activity-edit-postin.php
+++ b/buddypress/common/js-templates/activity/parts/bp-activity-edit-postin.php
@@ -1,0 +1,18 @@
+<script type="text/html" id="tmpl-activity-edit-postin">
+	<div id="whats-new-post-in-box">
+		<select disabled id="whats-new-post-in">
+			<# if ( data.object !== 'user' ) { #>
+			<option><?php esc_html_e( 'Post in: Group', 'buddyboss' ); ?></option>
+			<# } #>
+			<# if ( data.object === 'user' ) { #>
+			<option><?php esc_html_e( 'Post in: Profile', 'buddyboss' ); ?></option>
+			<# } #>
+		</select>
+
+		<# if ( data.group_name ) { #>
+			<div id="whats-new-post-in-box-items">
+				<input disabled type="text" id="activity-autocomplete" value="{{{data.group_name}}}" />
+			</div>
+		<# } #>
+	</div>
+</script>

--- a/buddypress/common/js-templates/activity/parts/bp-activity-link-preview.php
+++ b/buddypress/common/js-templates/activity/parts/bp-activity-link-preview.php
@@ -1,0 +1,44 @@
+<script type="text/html" id="tmpl-activity-link-preview">
+	<# if ( data.link_scrapping ) { #>
+	<# if ( data.link_loading ) { #>
+	<span class="activity-url-scrapper-loading activity-ajax-loader"><?php esc_html_e( 'Loading preview...', 'buddyboss' ) ?></span>
+	<# } #>
+	<# if ( data.link_success || data.link_error ) { #>
+	<div class="activity-link-preview-container">
+
+		<# if ( data.link_success && ! data.link_error ) { #>
+		<p class="activity-link-preview-title">{{{data.link_title}}}</p>
+		<# } #>
+
+		<# if ( data.link_images && data.link_images.length && data.link_success && ! data.link_error ) { #>
+		<div id="activity-url-scrapper-img-holder">
+			<div class="activity-link-preview-image">
+				<img src="{{{data.link_images[data.link_image_index]}}}"/>
+				<a title="Cancel Preview Image" href="#" id="activity-link-preview-close-image">
+					<i class="bb-icons bb-icon-close"></i>
+				</a>
+			</div>
+			<# if ( data.link_images.length > 1 ) { #>
+			<div class="activity-url-thumb-nav">
+				<button type="button" id="activity-url-prevPicButton"><span class="bb-icons bb-icon-angle-left"></span></button>
+				<button type="button" id="activity-url-nextPicButton"><span class="bb-icons bb-icon-angle-right"></span></button>
+				<div id="activity-url-scrapper-img-count">
+					<?php esc_html_e( 'Image', 'buddyboss' ) ?> <# print(data.link_image_index + 1) #>&nbsp;<?php esc_html_e( 'of', 'buddyboss' ) ?>&nbsp;<# print(data.link_images.length) #>
+				</div>
+			</div>
+			<# } #>
+		</div>
+		<# } #>
+
+		<# if ( data.link_success && ! data.link_error ) { #>
+		<div class="activity-link-preview-excerpt"><p>{{{data.link_description}}}</p></div>
+		<# } #>
+
+		<# if ( data.link_error && ! data.link_success ) { #>
+		<div id="activity-url-error" class="activity-url-error">{{data.link_error_msg}}</div>
+		<# } #>
+		<a title="<?php _e( 'Cancel Preview', 'buddyboss' ); ?>" href="#" id="activity-close-link-suggestion"><i class="bb-icons bb-icon-close"></i></a>
+	</div>
+	<# } #>
+	<# } #>
+</script>

--- a/buddypress/common/js-templates/activity/parts/bp-activity-media.php
+++ b/buddypress/common/js-templates/activity/parts/bp-activity-media.php
@@ -1,0 +1,3 @@
+<script type="text/html" id="tmpl-activity-media">
+	<div class="dropzone closed" id="activity-post-media-uploader"></div>
+</script>

--- a/buddypress/common/js-templates/activity/parts/bp-activity-post-form-avatar.php
+++ b/buddypress/common/js-templates/activity/parts/bp-activity-post-form-avatar.php
@@ -1,0 +1,8 @@
+<script type="text/html" id="tmpl-activity-post-form-avatar">
+	<# if ( data.display_avatar ) {  #>
+	<a class="activity-post-avatar" href="{{data.user_domain}}">
+		<img src="{{{data.avatar_url}}}" class="avatar user-{{data.user_id}}-avatar avatar-{{data.avatar_width}} photo" width="{{data.avatar_width}}" height="{{data.avatar_width}}" alt="{{data.avatar_alt}}" />
+		<span class="user-name">{{data.user_display_name}}</span>
+	</a>
+	<# } #>
+</script>

--- a/buddypress/common/js-templates/activity/parts/bp-activity-post-form-buttons.php
+++ b/buddypress/common/js-templates/activity/parts/bp-activity-post-form-buttons.php
@@ -1,0 +1,3 @@
+<script type="text/html" id="tmpl-activity-post-form-buttons">
+	<button type="button" class="button dashicons {{data.icon}}" data-button="{{data.id}}"><span class="bp-screen-reader-text">{{data.caption}}</span></button>
+</script>

--- a/buddypress/common/js-templates/activity/parts/bp-activity-post-form-feedback.php
+++ b/buddypress/common/js-templates/activity/parts/bp-activity-post-form-feedback.php
@@ -1,0 +1,3 @@
+<script type="text/html" id="tmpl-activity-post-form-feedback">
+	<span class="bp-icon" aria-hidden="true"></span><p>{{{data.message}}}</p>
+</script>

--- a/buddypress/common/js-templates/activity/parts/bp-activity-post-form-options.php
+++ b/buddypress/common/js-templates/activity/parts/bp-activity-post-form-options.php
@@ -1,0 +1,3 @@
+<script type="text/html" id="tmpl-activity-post-form-options">
+	<?php bp_nouveau_activity_hook( '', 'post_form_options' ); ?>
+</script>

--- a/buddypress/common/js-templates/activity/parts/bp-activity-post-form-privacy.php
+++ b/buddypress/common/js-templates/activity/parts/bp-activity-post-form-privacy.php
@@ -1,0 +1,7 @@
+<script type="text/html" id="tmpl-activity-post-form-privacy">
+    <select id="bp-activity-privacy" class="bp-activity-privacy" name="privacy">
+	    <?php foreach( bp_activity_get_visibility_levels() as $key => $privacy ) : ?>
+            <option value="<?php echo $key; ?>"><?php echo $privacy; ?></option>
+	    <?php endforeach; ?>
+    </select>
+</script>

--- a/buddypress/common/js-templates/activity/parts/bp-activity-target-item.php
+++ b/buddypress/common/js-templates/activity/parts/bp-activity-target-item.php
@@ -1,0 +1,17 @@
+<script type="text/html" id="tmpl-activity-target-item">
+	<# if ( data.selected ) { #>
+	<input type="hidden" value="{{data.id}}">
+	<# } #>
+
+	<# if ( data.avatar_url ) { #>
+	<img src="{{data.avatar_url}}" class="avatar {{data.object_type}}-{{data.id}}-avatar photo" alt="" />
+	<# } #>
+
+	<span class="bp-item-name">{{data.name}}</span>
+
+	<# if ( data.selected ) { #>
+	<button type="button" class="bp-remove-item dashicons dashicons-no" data-item_id="{{data.id}}">
+		<span class="bp-screen-reader-text"><?php esc_html_e( 'Remove item', 'buddyboss' ); ?></span>
+	</button>
+	<# } #>
+</script>

--- a/buddypress/common/js-templates/activity/parts/bp-gif-media-search-dropdown.php
+++ b/buddypress/common/js-templates/activity/parts/bp-gif-media-search-dropdown.php
@@ -1,0 +1,12 @@
+<script type="text/html" id="tmpl-gif-media-search-dropdown">
+	<div class="gif-search-content">
+		<div class="gif-search-query">
+			<input type="search" placeholder="<?php _e('Search GIPHY', 'buddyboss'); ?>" class="search-query-input" />
+			<span class="search-icon"></span>
+		</div>
+		<div class="gif-search-results" id="gif-search-results">
+			<ul class="gif-search-results-list" >
+			</ul>
+		</div>
+	</div>
+</script>

--- a/buddypress/common/js-templates/activity/parts/bp-gif-result-item.php
+++ b/buddypress/common/js-templates/activity/parts/bp-gif-result-item.php
@@ -1,0 +1,5 @@
+<script type="text/html" id="tmpl-gif-result-item">
+	<a class="found-media-item" href="{{{data.images.original.url}}}" data-id="{{data.id}}">
+		<img src="{{{data.images.fixed_width.url}}}" />
+	</a>
+</script>

--- a/buddypress/common/js-templates/activity/parts/bp-whats-new-toolbar.php
+++ b/buddypress/common/js-templates/activity/parts/bp-whats-new-toolbar.php
@@ -1,0 +1,38 @@
+<script type="text/html" id="tmpl-whats-new-toolbar">
+
+	<?php if ( bp_is_active( 'media' ) ) : ?>
+		<div class="post-elements-buttons-item show-toolbar"  data-bp-tooltip-pos="up-left" data-bp-tooltip="<?php esc_html_e( 'Show formatting', 'buddyboss' ); ?>" data-bp-tooltip-hide="<?php esc_html_e( 'Hide formatting', 'buddyboss' ); ?>" data-bp-tooltip-show="<?php esc_html_e( 'Show formatting', 'buddyboss' ); ?>">
+		<a href="#" id="show-toolbar-button" class="toolbar-button bp-tooltip">
+			<span class="bb-icon bb-icon-text-format"></span>
+		</a>
+	</div>
+	<?php endif; ?>
+	<?php if ( bp_is_active( 'media' ) && ( ( bp_is_activity_directory() && ( bp_is_profile_media_support_enabled() || bp_is_group_media_support_enabled() ) ) || ( bp_is_user_activity() && bp_is_profile_media_support_enabled() ) || ( bp_is_group_activity() && bp_is_group_media_support_enabled() ) ) ) : ?>
+        <div class="post-elements-buttons-item post-media media-support">
+			<a href="#" id="activity-media-button" class="toolbar-button bp-tooltip" data-bp-tooltip-pos="up" data-bp-tooltip="<?php esc_html_e( 'Attach a photo', 'buddyboss' ); ?>">
+				<i class="bb-icon bb-icon-camera-small"></i>
+			</a>
+		</div>
+	<?php endif; ?>
+	<?php
+	$extensions = ( function_exists( 'bp_document_get_allowed_extension' ) ) ? bp_document_get_allowed_extension() : '';
+	if ( bp_is_active( 'media' ) && ! empty( $extensions ) && ( ( bp_is_activity_directory() && ( bp_is_profile_document_support_enabled() || bp_is_group_document_support_enabled() ) ) || ( bp_is_user_activity() && bp_is_profile_document_support_enabled() ) || ( bp_is_group_activity() && bp_is_group_document_support_enabled() ) ) ) :
+        ?>
+		<div class="post-elements-buttons-item post-media document-support">
+			<a href="#" id="activity-document-button" class="toolbar-button bp-tooltip" data-bp-tooltip-pos="up" data-bp-tooltip="<?php esc_html_e( 'Attach a document', 'buddyboss' ); ?>">
+				<i class="bb-icon bb-icon-attach"></i>
+			</a>
+		</div>
+	<?php endif; ?>
+	<?php if ( bp_is_active( 'media' ) && ( ( bp_is_activity_directory() && ( bp_is_profiles_gif_support_enabled() || bp_is_groups_gif_support_enabled() ) ) || ( bp_is_user_activity() && bp_is_profiles_gif_support_enabled() ) || ( bp_is_group_activity() && bp_is_groups_gif_support_enabled() ) ) ) : ?>
+		<div class="post-elements-buttons-item post-gif">
+			<div class="gif-media-search">
+				<a href="#" id="activity-gif-button" class="toolbar-button bp-tooltip" data-bp-tooltip-pos="up" data-bp-tooltip="<?php esc_html_e( 'Post a GIF', 'buddyboss' ); ?>"><i class="bb-icon bb-icon-gif"></i></a>
+				<div class="gif-media-search-dropdown"></div>
+			</div>
+		</div>
+	<?php endif; ?>
+	<?php if ( bp_is_active( 'media' ) && ( ( bp_is_activity_directory() && ( bp_is_profiles_emoji_support_enabled() || bp_is_groups_emoji_support_enabled() ) ) || ( bp_is_user_activity() && bp_is_profiles_emoji_support_enabled() ) || ( bp_is_group_activity() && bp_is_groups_emoji_support_enabled() ) ) ) : ?>
+		<div class="post-elements-buttons-item post-emoji bp-tooltip" data-bp-tooltip-pos="up" data-bp-tooltip="<?php esc_html_e( 'Insert an emoji', 'buddyboss' ); ?>"></div>
+	<?php endif; ?>
+</script>

--- a/buddypress/common/js-templates/invites/index.php
+++ b/buddypress/common/js-templates/invites/index.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * BP Nouveau Invites main template.
+ *
+ * This template is used to inject the BuddyPress Backbone views
+ * dealing with invites.
+ *
+ * @since BuddyPress 3.0.0
+ * @version 3.1.0
+ */
+?>
+
+<?php if ( bp_is_group_create() ) : ?>
+
+	<h3 class="bp-screen-title creation-step-name">
+		<?php esc_html_e( 'Invite Members', 'buddyboss' ); ?>
+	</h3>
+
+<?php else : ?>
+
+	<h2 class="bp-screen-title">
+		<?php esc_html_e( 'Invite Members', 'buddyboss' ); ?>
+	</h2>
+
+<?php endif; ?>
+
+<div id="group-invites-container">
+
+	<nav class="<?php bp_nouveau_single_item_subnav_classes(); ?>" id="subnav" role="navigation" aria-label="<?php esc_attr_e( 'Group invitations menu', 'buddyboss' ); ?>"></nav>
+
+	<div class="group-invites-column">
+		<div class="subnav-filters group-subnav-filters bp-invites-filters"></div>
+		<div class="bp-invites-feedback"></div>
+		<div class="members bp-invites-content"></div>
+	</div>
+
+</div>
+

--- a/buddypress/common/js-templates/invites/parts/bp-group-invites-feedback.php
+++ b/buddypress/common/js-templates/invites/parts/bp-group-invites-feedback.php
@@ -1,0 +1,6 @@
+<script type="text/html" id="tmpl-bp-group-invites-feedback">
+	<div class="bp-feedback {{data.type}}">
+		<span class="bp-icon" aria-hidden="true"></span>
+		<p>{{{data.message}}}</p>
+	</div>
+</script>

--- a/buddypress/common/js-templates/invites/parts/bp-invites-filters.php
+++ b/buddypress/common/js-templates/invites/parts/bp-invites-filters.php
@@ -1,0 +1,15 @@
+<script type="text/html" id="tmpl-bp-invites-filters">
+	<div class="group-invites-search subnav-search clearfix" role="search" >
+		<div class="bp-search">
+			<form action="" method="get" id="group_invites_search_form" class="bp-invites-search-form" data-bp-search="{{data.scope}}">
+				<label for="group_invites_search" class="bp-screen-reader-text"><?php bp_nouveau_search_default_text( __( 'Search Members', 'buddyboss' ), false ); ?></label>
+				<input type="search" id="group_invites_search" placeholder="<?php esc_attr_e( 'Search', 'buddyboss' ); ?>"/>
+
+				<button type="submit" id="group_invites_search_submit" class="nouveau-search-submit">
+					<span class="bb-icons bb-icon-search" aria-hidden="true"></span>
+					<span id="button-text" class="bp-screen-reader-text"><?php esc_html_e( 'Search', 'buddyboss' ); ?></span>
+				</button>
+			</form>
+		</div>
+	</div>
+</script>

--- a/buddypress/common/js-templates/invites/parts/bp-invites-form.php
+++ b/buddypress/common/js-templates/invites/parts/bp-invites-form.php
@@ -1,0 +1,10 @@
+<script type="text/html" id="tmpl-bp-invites-form">
+
+	<label for="send-invites-control"><?php esc_html_e( 'Optional: Customize the message of your invite.', 'buddyboss' ); ?></label>
+	<textarea id="send-invites-control" class="bp-faux-placeholder-label" placeholder="<?php _e( 'Type message','buddyboss' ); ?>"></textarea>
+
+	<div class="action">
+		<button type="button" id="bp-invites-reset" class="button bp-secondary-action"><?php esc_html_e( 'Cancel', 'buddyboss' ); ?></button>
+		<button type="button" id="bp-invites-send" class="button bp-primary-action"><?php esc_html_e( 'Send', 'buddyboss' ); ?></button>
+	</div>
+</script>

--- a/buddypress/common/js-templates/invites/parts/bp-invites-nav.php
+++ b/buddypress/common/js-templates/invites/parts/bp-invites-nav.php
@@ -1,0 +1,3 @@
+<script type="text /html" id="tmpl-bp-invites-nav">
+	<a href="{{data.href}}" class="bp-invites-nav-item" data-nav="{{data.id}}">{{data.name}}</a>
+</script>

--- a/buddypress/common/js-templates/invites/parts/bp-invites-paginate.php
+++ b/buddypress/common/js-templates/invites/parts/bp-invites-paginate.php
@@ -1,0 +1,15 @@
+<script type="text/html" id="tmpl-bp-invites-paginate">
+	<# if ( 1 !== data.page ) { #>
+	<a href="#previous-page" id="bp-invites-prev-page" class="button invite-button bp-tooltip" data-bp-tooltip-pos="up" data-bp-tooltip="<?php esc_attr_e( 'Previous page', 'buddyboss' ); ?>">
+		<span class="dashicons dashicons-arrow-left" aria-hidden="true"></span>
+		<span class="bp-screen-reader-text"><?php esc_html_e( 'Previous page', 'buddyboss' ); ?></span>
+	</a>
+	<# } #>
+
+	<# if ( data.total_page !== data.page ) { #>
+	<a href="#next-page" id="bp-invites-next-page" class="button invite-button bp-tooltip" data-bp-tooltip-pos="up" data-bp-tooltip="<?php esc_attr_e( 'Next page', 'buddyboss' ); ?>">
+		<span class="bp-screen-reader-text"><?php esc_html_e( 'Previous page', 'buddyboss' ); ?></span>
+		<span class="dashicons dashicons-arrow-right" aria-hidden="true"></span>
+	</a>
+	<# } #>
+</script>

--- a/buddypress/common/js-templates/invites/parts/bp-invites-selection.php
+++ b/buddypress/common/js-templates/invites/parts/bp-invites-selection.php
@@ -1,0 +1,5 @@
+<script type="text/html" id="tmpl-bp-invites-selection">
+	<a href="#uninvite-user-{{data.id}}" class="bp-tooltip" data-bp-tooltip-pos="up" data-bp-tooltip="{{data.uninviteTooltip}}" aria-label="{{data.uninviteTooltip}}">
+		<img src="{{data.avatar}}" class="avatar" alt=""/>
+	</a>
+</script>

--- a/buddypress/common/js-templates/invites/parts/bp-invites-users.php
+++ b/buddypress/common/js-templates/invites/parts/bp-invites-users.php
@@ -1,0 +1,55 @@
+<script type="text/html" id="tmpl-bp-invites-users">
+	<div class="item-avatar">
+		<img src="{{data.avatar}}" class="avatar" alt="">
+	</div>
+
+	<div class="item">
+		<div class="list-title member-name">
+			{{data.name}}
+		</div>
+
+		<# if ( undefined !== data.is_sent ) { #>
+		<div class="item-meta">
+			<# if ( undefined !== data.invited_by ) { #>
+			<ul class="group-inviters">
+				<li><?php esc_html_e( 'Invited by:', 'buddyboss' ); ?></li>
+				<# for ( i in data.invited_by ) { #>
+				<li><a href="{{data.invited_by[i].user_link}}" class="bp-tooltip" data-bp-tooltip-pos="left" data-bp-tooltip="{{data.invited_by[i].user_name}}"><img src="{{data.invited_by[i].avatar}}" width="30px" class="avatar mini" alt="{{data.invited_by[i].user_name}}"></a></li>
+				<# } #>
+			</ul>
+			<# } #>
+
+			<p class="status">
+				<# if ( false === data.is_sent ) { #>
+				<?php esc_html_e( 'The invite has not been sent.', 'buddyboss' ); ?>
+				<# } else { #>
+				<?php esc_html_e( 'The invite has been sent.', 'buddyboss' ); ?>
+				<# } #>
+			</p>
+		</div>
+		<# } #>
+	</div>
+
+	<div class="action">
+		<# if ( undefined === data.is_sent || ( false === data.is_sent && true === data.can_edit ) ) { #>
+		<button type="button" class="button invite-button group-add-remove-invite-button bp-tooltip bp-icons<# if ( data.selected ) { #> selected<# } #>" data-bp-tooltip-pos="left" data-bp-tooltip="<# if ( data.selected ) { #><?php esc_attr_e( 'Cancel invitation', 'buddyboss' ); ?><# } else { #><?php esc_attr_e( 'Invite', 'buddyboss' ); ?><# } #>">
+			<span class="icons" aria-hidden="true"></span>
+			<span class="bp-screen-reader-text">
+					<# if ( data.selected ) { #>
+						<?php esc_html_e( 'Cancel invitation', 'buddyboss' ); ?>
+					<# } else { #>
+						<?php esc_html_e( 'Invite', 'buddyboss' ); ?>
+					<# } #>
+				</span>
+		</button>
+		<# } #>
+
+		<# if ( undefined !== data.can_edit && true === data.can_edit ) { #>
+		<button type="button" class="button invite-button group-remove-invite-button bp-tooltip bp-icons" data-bp-tooltip-pos="left" data-bp-tooltip="<?php esc_attr_e( 'Cancel invitation', 'buddyboss' ); ?>">
+			<span class=" icons" aria-hidden="true"></span>
+			<span class="bp-screen-reader-text"><?php esc_attr_e( 'Cancel invitation', 'buddyboss' ); ?></span>
+		</button>
+		<# } #>
+	</div>
+
+</script>

--- a/buddypress/common/js-templates/messages/index.php
+++ b/buddypress/common/js-templates/messages/index.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * BP Nouveau Messages main template.
+ *
+ * This template is used to inject the BuddyPress Backbone views
+ * dealing with user's private messages.
+ *
+ * @since BuddyPress 3.0.0
+ * @version 3.1.0
+ */
+?>
+
+<input type="hidden" id="thread-id" value="" />
+<div class="bp-messages-container">
+	<div class="bp-messages-nav-panel">
+		<?php bp_get_template_part( 'members/single/parts/item-subnav' ); ?>
+		<div class="subnav-filters filters user-subnav bp-messages-filters push-right" id="subsubnav"></div><!--This is required for filters-->
+		<div class="bp-messages-threads-list" id="bp-messages-threads-list"></div>
+	</div>
+	<div class="bp-messages-content"></div>
+
+</div>
+
+
+
+<?php
+if ( bp_is_active( 'media' ) && bp_is_messages_media_support_enabled() ) {
+	bp_get_template_part( 'media/theatre' );
+}
+if ( bp_is_active( 'media' ) && bp_is_messages_document_support_enabled() ) {
+	bp_get_template_part( 'document/theatre' );
+}
+
+    /**
+     * Split each js template to its own file. Easier for child theme to
+     * overwrite individual parts.
+     *
+     * @version Buddyboss 1.0.0
+     */
+    $template_parts = apply_filters( 'bp_messages_js_template_parts', [
+        'parts/bp-messages-feedback',
+        'parts/bp-messages-loading',
+        'parts/bp-messages-hook',
+        'parts/bp-messages-form',
+        'parts/bp-messages-editor',
+        'parts/bp-messages-paginate',
+        'parts/bp-messages-filters',
+        'parts/bp-messages-thread',
+        'parts/bp-messages-single-header',
+        'parts/bp-messages-single-load-more',
+        'parts/bp-messages-single-list',
+        'parts/bp-messages-single',
+        'parts/bp-messages-editor-toolbar',
+        'parts/bp-messages-media',
+        'parts/bp-messages-document',
+        'parts/bp-messages-attached-gif',
+        'parts/bp-messages-gif-media-search-dropdown',
+        'parts/bp-messages-gif-result-item',
+        'parts/bp-messages-no-threads',
+    ] );
+
+    foreach ( $template_parts as $template_part ) {
+        bp_get_template_part( 'common/js-templates/messages/' . $template_part );
+    }

--- a/buddypress/common/js-templates/messages/parts/bp-messages-attached-gif.php
+++ b/buddypress/common/js-templates/messages/parts/bp-messages-attached-gif.php
@@ -1,0 +1,10 @@
+<script type="text/html" id="tmpl-messages-attached-gif">
+	<# if ( ! _.isUndefined( data.gif_data.images ) ) { #>
+	<div class="gif-image-container">
+		<img src="{{data.gif_data.images.original.url}}" alt="">
+	</div>
+	<div class="gif-image-remove gif-image-overlay">
+		<i class="bb-icon-close"></i>
+	</div>
+	<# } #>
+</script>

--- a/buddypress/common/js-templates/messages/parts/bp-messages-document.php
+++ b/buddypress/common/js-templates/messages/parts/bp-messages-document.php
@@ -1,0 +1,3 @@
+<script type="text/html" id="tmpl-messages-document">
+	<div class="dropzone closed" id="messages-post-document-uploader"></div>
+</script>

--- a/buddypress/common/js-templates/messages/parts/bp-messages-editor-toolbar.php
+++ b/buddypress/common/js-templates/messages/parts/bp-messages-editor-toolbar.php
@@ -1,0 +1,50 @@
+<script type="text/html" id="tmpl-whats-new-messages-toolbar">
+
+<?php if ( ! bp_is_active( 'media' ) ) : ?>
+<div class="media-off">
+<?php endif; ?>
+
+	<?php if ( bp_is_active( 'media' ) ) : ?>
+
+		<div class="post-elements-buttons-item show-toolbar"  data-bp-tooltip-pos="down-left" data-bp-tooltip="<?php esc_html_e( 'Show formatting', 'buddyboss' ); ?>" data-bp-tooltip-hide="<?php esc_html_e( 'Hide formatting', 'buddyboss' ); ?>" data-bp-tooltip-show="<?php esc_html_e( 'Show formatting', 'buddyboss' ); ?>">
+			<a href="#" id="show-toolbar-button" class="toolbar-button bp-tooltip">
+				<span class="bb-icon bb-icon-text-format"></span>
+			</a>
+		</div>
+
+		<div class="post-elements-buttons-item post-media post-media-photo-support">
+			<a href="#" id="messages-media-button" class="toolbar-button bp-tooltip" data-bp-tooltip-pos="down" data-bp-tooltip="<?php esc_html_e( 'Attach a photo', 'buddyboss' ); ?>">
+				<i class="bb-icon bb-icon-camera-small"></i>
+			</a>
+		</div>
+
+		<?php
+		$extensions = bp_document_get_allowed_extension();
+		if ( ! empty( $extensions ) ) :
+			?>
+			<div class="post-elements-buttons-item post-media post-media-document-support">
+				<a href="#" id="messages-document-button" class="toolbar-button bp-tooltip" data-bp-tooltip-pos="down" data-bp-tooltip="<?php esc_html_e( 'Attach a document', 'buddyboss' ); ?>">
+					<i class="bb-icon bb-icon-attach"></i>
+				</a>
+			</div>
+		<?php endif; ?>
+
+		<div class="post-elements-buttons-item post-gif post-media-gif-support">
+			<div class="gif-media-search">
+				<a href="#" id="messages-gif-button" class="toolbar-button bp-tooltip" data-bp-tooltip-pos="down" data-bp-tooltip="<?php esc_html_e( 'Post a GIF', 'buddyboss' ); ?>">
+					<i class="bb-icon bb-icon-gif"></i>
+				</a>
+				<div class="gif-media-search-dropdown"></div>
+			</div>
+		</div>
+
+		<div class="post-elements-buttons-item post-emoji bp-tooltip post-media-emoji-support" data-bp-tooltip-pos="down" data-bp-tooltip="<?php esc_html_e( 'Insert an emoji', 'buddyboss' ); ?>"></div>
+
+
+	<?php endif; ?>
+
+<?php if ( ! bp_is_active( 'media' ) ) : ?>
+</div>
+<?php endif; ?>
+
+</script>

--- a/buddypress/common/js-templates/messages/parts/bp-messages-editor.php
+++ b/buddypress/common/js-templates/messages/parts/bp-messages-editor.php
@@ -1,0 +1,3 @@
+<script type="text/html" id="tmpl-bp-messages-editor">
+    <div id="message_content" name="message_content" tabindex="3"></div>
+</script>

--- a/buddypress/common/js-templates/messages/parts/bp-messages-feedback.php
+++ b/buddypress/common/js-templates/messages/parts/bp-messages-feedback.php
@@ -1,0 +1,6 @@
+<script type="text/html" id="tmpl-bp-messages-feedback">
+	<div class="bp-feedback {{data.type}}">
+		<span class="bp-icon" aria-hidden="true"></span>
+		<p>{{{data.message}}}</p>
+	</div>
+</script>

--- a/buddypress/common/js-templates/messages/parts/bp-messages-filters.php
+++ b/buddypress/common/js-templates/messages/parts/bp-messages-filters.php
@@ -1,0 +1,8 @@
+<script type="text/html" id="tmpl-bp-messages-filters">
+	<li class="user-messages-search" role="search" data-bp-search="{{data.box}}">
+		<div class="bp-search messages-search">
+			<?php bp_nouveau_message_search_form(); ?>
+		</div>
+	</li>
+	<li class="user-messages-bulk-actions"></li>
+</script>

--- a/buddypress/common/js-templates/messages/parts/bp-messages-form.php
+++ b/buddypress/common/js-templates/messages/parts/bp-messages-form.php
@@ -1,0 +1,39 @@
+<script type="text/html" id="tmpl-bp-messages-form">
+	<?php bp_nouveau_messages_hook( 'before', 'compose_content' ); ?>
+
+	<div class="bp-messages-form-header">
+		<label for="send-to-input"><?php esc_html_e( 'New Message', 'buddyboss' ); ?></label>
+		<a href="#" class="bp-close-compose-form"><span class="bb-icons bb-icon-x"></span></a>
+	</div>
+
+	<div class="bp-messages-feedback"></div>
+
+	<select
+		name="send_to[]"
+		class="send-to-input"
+		id="send-to-input"
+		placeholder="<?php esc_html_e( 'Type the names of one or more people', 'buddyboss' ); ?>"
+		autocomplete="off"
+		multiple="multiple"
+		style="width: 100%"
+	>
+		<?php if ( ! empty( $_GET['r'] ) ):
+
+			if ( bp_is_username_compatibility_mode() ) {
+				$user_id = bp_core_get_userid( urldecode( $_GET['r'] ) );
+			} else {
+				$user_id = bp_core_get_userid_from_nicename( $_GET['r'] );
+			}
+			$name = bp_core_get_user_displayname( $user_id );
+			?>
+			<option value="@<?php echo esc_attr( $_GET['r'] ); ?>" selected data-action="<?php echo $user_id; ?>"><?php echo esc_html( $name ); ?></option>
+		<?php endif; ?>
+	</select>
+
+	<div id="bp-message-content"></div>
+
+	<?php bp_nouveau_messages_hook( 'after', 'compose_content' ); ?>
+</script>
+<script type="text/html" id="tmpl-bp-messages-form-submit">
+    <input type="button" id="bp-messages-send" class="button bp-primary-action" value="<?php esc_attr_e( 'Send', 'buddyboss' ); ?>"/>
+</script>

--- a/buddypress/common/js-templates/messages/parts/bp-messages-gif-media-search-dropdown.php
+++ b/buddypress/common/js-templates/messages/parts/bp-messages-gif-media-search-dropdown.php
@@ -1,0 +1,12 @@
+<script type="text/html" id="tmpl-messages-gif-media-search-dropdown">
+	<div class="gif-search-content">
+		<div class="gif-search-query">
+			<input type="search" placeholder="<?php _e('Search GIPHY', 'buddyboss'); ?>" class="search-query-input" />
+			<span class="search-icon"></span>
+		</div>
+		<div class="gif-search-results" id="gif-search-results">
+			<ul class="gif-search-results-list" >
+			</ul>
+		</div>
+	</div>
+</script>

--- a/buddypress/common/js-templates/messages/parts/bp-messages-gif-result-item.php
+++ b/buddypress/common/js-templates/messages/parts/bp-messages-gif-result-item.php
@@ -1,0 +1,5 @@
+<script type="text/html" id="tmpl-messages-gif-result-item">
+	<a class="found-media-item" href="{{{data.images.original.url}}}" data-id="{{data.id}}">
+		<img src="{{{data.images.fixed_width.url}}}" />
+	</a>
+</script>

--- a/buddypress/common/js-templates/messages/parts/bp-messages-hook.php
+++ b/buddypress/common/js-templates/messages/parts/bp-messages-hook.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * This view is used to inject hooks buffer
+ */
+?>
+<script type="text/html" id="tmpl-bp-messages-hook">
+	{{{data.extraContent}}}
+</script>

--- a/buddypress/common/js-templates/messages/parts/bp-messages-loading.php
+++ b/buddypress/common/js-templates/messages/parts/bp-messages-loading.php
@@ -1,0 +1,3 @@
+<script type="text/html" id="tmpl-bp-messages-loading">
+    <i class="dashicons dashicons-update animate-spin"></i>
+</script>

--- a/buddypress/common/js-templates/messages/parts/bp-messages-media.php
+++ b/buddypress/common/js-templates/messages/parts/bp-messages-media.php
@@ -1,0 +1,3 @@
+<script type="text/html" id="tmpl-messages-media">
+	<div class="dropzone closed" id="messages-post-media-uploader"></div>
+</script>

--- a/buddypress/common/js-templates/messages/parts/bp-messages-no-threads.php
+++ b/buddypress/common/js-templates/messages/parts/bp-messages-no-threads.php
@@ -1,0 +1,9 @@
+<script type="text/html" id="tmpl-bp-messages-no-threads">
+	<div class="no-message-wrap">
+		<span class="dashicons dashicons-email-alt"></span>
+		<div class="no-message-content">
+			<h3><?php _e( 'No new messages yet!', 'buddyboss' ); ?></h3>
+			<p><?php _e( 'Looks like you haven\'t initiated a conversation with any other member.', 'buddyboss' ); ?></p>
+		</div>
+	</div>
+</script>

--- a/buddypress/common/js-templates/messages/parts/bp-messages-paginate.php
+++ b/buddypress/common/js-templates/messages/parts/bp-messages-paginate.php
@@ -1,0 +1,15 @@
+<script type="text/html" id="tmpl-bp-messages-paginate">
+	<# if ( 1 !== data.page ) { #>
+	<button id="bp-messages-prev-page"class="button messages-button">
+		<span class="dashicons dashicons-arrow-left"></span>
+		<span class="bp-screen-reader-text"><?php esc_html_e( 'Previous page', 'buddyboss' ); ?></span>
+	</button>
+	<# } #>
+
+	<# if ( data.total_page !== data.page ) { #>
+	<button id="bp-messages-next-page"class="button messages-button">
+		<span class="dashicons dashicons-arrow-right"></span>
+		<span class="bp-screen-reader-text"><?php esc_html_e( 'Previous page', 'buddyboss' ); ?></span>
+	</button>
+	<# } #>
+</script>

--- a/buddypress/common/js-templates/messages/parts/bp-messages-single-header.php
+++ b/buddypress/common/js-templates/messages/parts/bp-messages-single-header.php
@@ -1,0 +1,169 @@
+<script type="text/html" id="tmpl-bp-messages-single-header">
+	<#    var other_recipients = _.reject(data.recipients, function(item) {    return item.is_you;    });
+
+	var current_user = _.find(data.recipients, function(item) {    return item.is_you == true;    });
+
+	var include_you = other_recipients.length >= 2;
+
+	if (other_recipients.length == 0) {    include_you = true;    }    #>
+
+	<header class="single-message-thread-header">
+		<a href="#" class="bp-back-to-thread-list"><span class="dashicons dashicons-arrow-left-alt2"></span></a> <# if ( undefined !== other_recipients ) { #>
+		<dl class="thread-participants">
+			<dt>
+				<# if ( data.group_name.length > 1 && data.is_group_thread ) { #> <span class="participants-name">
+						<# if ( data.is_deleted ) { #>
+							{{data.group_name}}
+						<# } else { #>
+							<a href="{{data.group_link}}">{{data.group_name}}</a>
+						<# } #>
+					</span>
+                <# } else { #>
+                    <# for ( i in other_recipients ) { #>
+                        <span class="participants-name">
+                            <# if ( other_recipients[i].is_deleted ) { #>
+                                {{other_recipients[i].user_name}}
+                             <# } else { #>
+                                <# if( other_recipients[i].user_link ) { #><a href="{{other_recipients[i].user_link}}">{{other_recipients[i].user_name}}</a><# } else { #>{{other_recipients[i].user_name}}<# } #><# } #><# if ( i != other_recipients.length -1 || ( i == other_recipients.length -1 ) && data.toOthers ) { #><?php _e( ',', 'buddyboss' ); ?><# } #>
+                        </span>
+                    <# } #>
+
+				<# } #>
+			</dt>
+			<dd>
+				<span class="thread-date"><?php esc_html_e( 'Started', 'buddyboss' ); ?> {{data.started_date}}</span>
+			</dd>
+		</dl>
+		<# } #>
+		<div class="actions">
+			<?php
+			if ( bp_current_user_can( 'bp_moderate' ) ) {
+				?>
+				<div class="message_actions">
+					<a href="#" class="message_action__anchor"> <i class="bb-icon-menu-dots-v"></i> </a>
+					<div class="message_action__list">
+						<ul>
+							<li class="unread"><a data-bp-action="unread" href="#"><?php esc_html_e( 'Mark unread',
+											'buddyboss' ); ?></a></li>
+							<li class="hide_thread">
+								<a data-bp-action="hide_thread" href="#"><?php esc_html_e( 'Hide conversation',
+											'buddyboss' ); ?></a>
+							</li>
+							<?php if ( bp_is_active( 'moderation' ) && bp_is_moderation_member_blocking_enable() ) { ?>
+								<# if ( other_recipients.length > 1 ) { #>
+	                                <li class="report_thread">
+	                                    <a id="mass-block-member" href="#mass-user-block-list" class="mass-block-member"><?php esc_html_e( 'Block a member', 'buddyboss' ); ?></a>
+	                                </li>
+								<# } else if ( other_recipients.length == 1 && other_recipients[0].is_blocked ) { #>
+	                                <li class="reported_thread">
+	                                    <a href="#"><?php esc_html_e( 'Blocked', 'buddyboss' );  ?></a>
+	                                </li>
+	                            <# } else if( other_recipients.length == 1 && true == other_recipients[0].can_be_blocked ) { #>
+	                                <li class="report_thread">
+	                                    <a id="report-content-<?php echo esc_attr( BP_Moderation_Members::$moderation_type ) ?>-{{other_recipients[0].id}}" href="#block-member" class="block-member" data-bp-content-id="{{other_recipients[0].id}}" data-bp-content-type="<?php echo esc_attr( BP_Moderation_Members::$moderation_type ); ?>" data-bp-nonce="<?php echo esc_attr( wp_create_nonce( 'bp-moderation-content' ) ); ?>"><?php esc_html_e( 'Block member', 'buddyboss' ); ?></a>
+	                                </li>
+	                            <# } #>
+							<?php } ?>
+							<li class="delete_messages">
+								<a data-bp-action="delete" href="#"><?php esc_html_e( 'Delete your messages', 'buddyboss' ); ?></a>
+							</li>
+							<li class="delete_thread">
+								<a data-bp-action="delete_thread" href="#"><?php esc_html_e( 'Delete conversation', 'buddyboss' ); ?></a>
+							</li>
+						</ul>
+					</div>
+				</div>
+				<?php
+			} else {
+
+				$old_user = false;
+				if ( class_exists( 'BP_Core_Members_Switching' ) ) {
+					$old_user = BP_Core_Members_Switching::get_old_user();
+				}
+				?>
+				<div class="message_actions">
+					<a href="#" class="message_action__anchor"> <i class="bb-icon-menu-dots-v"></i> </a>
+					<div class="message_action__list">
+						<ul>
+							<li class="unread"><a data-bp-action="unread" href="#"><?php esc_html_e( 'Mark unread',
+											'buddyboss' ); ?></a></li>
+							<li class="hide_thread">
+								<a data-bp-action="hide_thread" href="#"><?php esc_html_e( 'Hide conversation',
+											'buddyboss' ); ?></a>
+							</li>
+							<?php if ( bp_is_active( 'moderation' ) && bp_is_moderation_member_blocking_enable() ) { ?>
+								<# if ( other_recipients.length > 1 ) { #>
+								<li class="report_thread">
+									<a id="mass-block-member" href="#mass-user-block-list" class="mass-block-member"><?php esc_html_e( 'Block a member', 'buddyboss' ); ?></a>
+								</li>
+								<# } else if ( other_recipients.length == 1 && other_recipients[0].is_blocked ) { #>
+	                                <li class="reported_thread">
+	                                    <a href="#"><?php esc_html_e( 'Blocked', 'buddyboss' );  ?></a>
+	                                </li>
+	                            <# } else if( other_recipients.length == 1 && true == other_recipients[0].can_be_blocked ) { #>
+	                            <li class="report_thread">
+	                                <a id="report-content-<?php echo esc_attr( BP_Moderation_Members::$moderation_type ) ?>-{{other_recipients[0].id}}" href="#block-member" class="block-member" data-bp-content-id="{{other_recipients[0].id}}" data-bp-content-type="<?php echo esc_attr( BP_Moderation_Members::$moderation_type ); ?>" data-bp-nonce="<?php echo esc_attr( wp_create_nonce( 'bp-moderation-content' ) ); ?>"><?php esc_html_e( 'Block member', 'buddyboss' ); ?></a>
+	                            </li>
+	                            <# } #>
+							<?php } ?>
+							<li class="delete_messages" data-bp-action="delete">
+								<a data-bp-action="delete" href="#"><?php esc_html_e( 'Delete your messages', 'buddyboss' ); ?></a>
+							</li>
+							<?php
+							if ( ! empty( $old_user ) ) {
+								?>
+								<li class="delete_thread">
+									<a data-bp-action="delete_thread" href="#"><?php esc_html_e( 'Delete conversation', 'buddyboss' ); ?></a>
+								</li>
+								<?php
+							}
+							?>
+						</ul>
+					</div>
+				</div>
+				<?php
+			}
+			?>
+		</div>
+		<?php if ( bp_is_active( 'moderation' ) && bp_is_moderation_member_blocking_enable() ) { ?>
+			<div id="mass-user-block-list" class="mass-user-block-list moderation-popup mfp-hide">
+				<div class="modal-mask bb-white bbm-model-wrap bbm-uploader-model-wrap">
+					<div class="modal-wrapper">
+						<div class="modal-container">
+							<header class="bb-model-header">
+								<h4><?php esc_html_e( 'Block a Member?', 'buddyboss' ); ?></h4>
+								<button title="<?php esc_attr_e( 'Close (Esc)', 'buddyboss' ); ?>" type="button" class="mfp-close"></button>
+							</header>
+							<div class="bb-report-type-wrp">
+								<# _.reject(other_recipients, function(item) {
+	                            if( false == item.can_be_blocked ) {
+	                                return false;
+	                            } #>
+								<div class="user-item-wrp">
+									<div class="user-avatar">
+										<img src="{{{item.avatar}}}" alt="{{item.user_name}}">
+									</div>
+									<div class="user-name">
+										{{item.user_name}}
+									</div>
+									<div class="user-actions">
+	                                    <# if ( true === item.is_blocked ) { #>
+	                                        <a id="reported-user" class="blocked-member button small disabled">
+	                                            <?php esc_html_e( 'Blocked', 'buddyboss' ); ?>
+	                                        </a>
+	                                    <# } else{ #>
+	                                        <a id="report-content-<?php echo esc_attr( BP_Moderation_Members::$moderation_type ) ?>-{{item.id}}" href="#block-member" class="block-member button small" data-bp-content-id="{{item.id}}" data-bp-content-type="<?php echo esc_attr( BP_Moderation_Members::$moderation_type ); ?>" data-bp-nonce="<?php echo esc_attr( wp_create_nonce( 'bp-moderation-content' ) ); ?>">
+	                                            <?php esc_html_e( 'Block', 'buddyboss' ); ?>
+	                                        </a>
+	                                    <# } #>
+									</div>
+								</div>
+								<# }); #>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		<?php } ?>
+	</header>
+</script>

--- a/buddypress/common/js-templates/messages/parts/bp-messages-single-list.php
+++ b/buddypress/common/js-templates/messages/parts/bp-messages-single-list.php
@@ -1,0 +1,170 @@
+<script type="text/html" id="tmpl-bp-messages-single-list">
+
+	<# if ( data.message_from && 'group' === data.message_from ) { #>
+	<div class="bp-single-message-wrap group-messages-highlight">
+	<# } else { #>
+	<div class="bp-single-message-wrap">
+	<# } #>
+
+        <# if ( ! data.is_user_suspended && ! data.is_user_blocked ) { #>
+		<div class="bp-avatar-wrap">
+			<# if ( data.is_deleted ) { #>
+				<img class="avatar" src="{{{data.sender_avatar}}}" alt="" />
+			<# } else if ( data.is_user_suspended || data.is_user_blocked  ) { #>
+				<img class="avatar" src="{{{data.sender_avatar}}}" alt="" />
+			<# } else { #>
+				<a href="{{data.sender_link}}" class="bp-user-avatar">
+					<img class="avatar" src="{{{data.sender_avatar}}}" alt="" />
+				</a>
+			<# } #>
+		</div>
+        <# } #>
+
+        <# if ( data.is_user_suspended || data.is_user_blocked ) { #>
+            <div class="bp-avatar-wrap bp-suspended-avatar">
+                <img class="avatar" src="{{{data.sender_avatar}}}" alt="Suspended Member Avatar">
+            </div>
+        <# } #>
+
+		<div class="bp-single-message-content">
+            <# if ( ! data.is_user_suspended && ! data.is_user_blocked ) { #>
+			<div class="message-metadata">
+				<# if ( data.beforeMeta ) { #>
+				<div class="bp-messages-hook before-message-meta">{{{data.beforeMeta}}}</div>
+				<# } #>
+
+				<# if ( data.is_deleted ) { #>
+					<# if ( data.sender_is_you ) { #>
+					<strong><?php _e( 'You', 'buddyboss' ); ?></strong>
+					<# } else { #>
+					<strong class="bp-user-deleted">{{data.sender_name}}</strong>
+					<# } #>
+				<# } else { #>
+                    <a href="{{data.sender_link}}" class="bp-user-link">
+                        <# if ( data.sender_is_you ) { #>
+                            <strong><?php _e( 'You', 'buddyboss' ); ?></strong>
+                        <# } else { #>
+                            <strong>{{data.sender_name}}</strong>
+                        <# } #>
+                    </a>
+				<# } #>
+
+				<# if ( ! data.is_user_suspended && ! data.is_user_blocked ) { #>
+					<time datetime="{{data.date.toISOString()}}" class="activity">{{data.display_date}}</time>
+
+					<# if ( data.afterMeta ) { #>
+						<div class="bp-messages-hook after-message-meta">{{{data.afterMeta}}}</div>
+					<# } #>
+				<# } #>
+			</div>
+            <# } #>
+
+            <# if ( data.beforeContent ) { #>
+            <div class="bp-messages-hook before-message-content">{{{data.beforeContent}}}</div>
+            <# } #>
+
+            <# if ( data.is_user_suspended || data.is_user_blocked ) { #>
+                <div class="message-metadata bp-suspended-meta">
+                    <strong>{{data.sender_name}}</strong>
+                </div>
+                <div class="bp-message-content-wrap bp-suspended-content">{{{data.content}}}</div>
+            <# } else { #>
+                <div class="bp-message-content-wrap">{{{data.content}}}</div>
+            <# } #>
+
+            <# if ( data.media ) { #>
+            <div class="bb-activity-media-wrap bb-media-length-{{data.media.length}}">
+                <# for ( i in data.media ) { #>
+                <div class="bb-activity-media-elem">
+                    <a class="bb-open-media-theatre bb-photo-cover-wrap"
+                       data-id="{{data.media[i].id}}"
+                       data-attachment-id="{{data.media[i].attachment_id}}"
+                       data-attachment-full="{{data.media[i].full}}"
+                       data-privacy="{{data.media[i].privacy}}"
+                       href="#">
+                        <img src="{{data.media[i].thumbnail}}" alt="{{data.media[i].title}}"/>
+                    </a>
+                </div>
+                <# } #>
+            </div>
+            <# } #>
+
+            <# if ( data.document ) { #>
+            <div class="bb-activity-media-wrap bb-media-length-{{data.document.length}}">
+                <# for ( i in data.document ) { #>
+                    <div class="bb-activity-media-elem document-activity " data-id="">
+                        <div class="document-description-wrap">
+                            <a href="{{data.document[i].url}}" class="entry-img" data-id="{{data.document[i].id}}" data-activity-id="{{data.document[i].id}}">
+                                <i class="{{data.document[i].svg_icon}}" ></i>
+                            </a>
+                            <a href="{{data.document[i].url}}"
+                               class="document-detail-wrap bb-open-document-theatre"
+                               data-id="{{data.document[i].id}}"
+                               data-activity-id=""
+                               data-icon-class={{data.document[i].svg_icon}}"
+                               data-attachment-id="{{data.document[i].attachment_id}}"
+                               data-attachment-full=""
+                               data-privacy="{{data.document[i].privacy}}"
+                               data-extension="{{data.document[i].extension}}"
+                               data-author="{{data.document[i].author}}"
+                               data-preview="{{data.document[i].preview}}"
+                               data-text-preview="{{data.document[i].text_preview}}"
+                               data-mp3-preview="{{data.document[i].mp3_preview}}"
+                               data-document-title="{{data.document[i].document_title}}"
+                               data-mirror-text="{{data.document[i].mirror_text}}">
+                                <span class="document-title">{{data.document[i].title}}.{{data.document[i].extension}}</span>
+                                <span class="document-description">{{data.document[i].size}}</span>
+                                {{{data.document[i].extension_description}}}
+                                <span class="document-helper-text"> <span> — </span> <span class="document-helper-text-inner">{{data.document[i].download_text}}</span></span>
+                            </a>
+                        </div>
+                        <div class="document-action-wrap">
+                            <a href="#" class="document-action_collapse" data-balloon-pos="down" data-balloon="{{data.document[i].collapse}}"><i class="bb-icon-arrow-up document-icon-collapse"></i></a>
+                            <a href="{{data.document[i].url}}" class="document-action_download" data-balloon-pos="up" data-balloon="{{data.document[i].download}}">
+                                <i class="bb-icon-download"></i>
+                            </a>
+
+                            <a href="#" target="_blank" class="document-action_more" data-balloon-pos="up" data-balloon="{{data.document[i].more_action}}">
+                                <i class="bb-icon-menu-dots-v"></i>
+                            </a>
+                            <div class="document-action_list">
+                                <ul>
+                                    <li class="copy_download_file_url">
+                                        <a href="{{data.document[i].url}}">{{data.document[i].copy_download_link}}</a>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                        {{{data.document[i].msg_preview}}}
+                    </div>
+                <# } #>
+            </div>
+
+            <# } #>
+
+            <# if ( data.gif ) { #>
+            <div class="activity-attached-gif-container">
+                <div class="gif-image-container">
+                    <div class="gif-player">
+                        <video preload="auto" playsinline poster="{{data.gif.preview_url}}" loop muted playsinline>
+                            <source src="{{data.gif.video_url}}" type="video/mp4">
+                        </video>
+                        <a href="#" class="gif-play-button">
+                            <span class="bb-icon-play-thin"></span>
+                        </a>
+                        <span class="gif-icon"></span>
+                    </div>
+                </div>
+            </div>
+            <# } #>
+
+            <# if ( data.afterContent ) { #>
+            <div class="bp-messages-hook after-message-content">{{{data.afterContent}}}</div>
+            <# } #>
+
+            <# if ( data.group_text && data.message_from && 'group' === data.message_from ) { #>
+                    <div class="bb-group-message-info">{{{data.group_text}}}</div>
+            <# } #>
+		</div>
+	</div>
+</script>

--- a/buddypress/common/js-templates/messages/parts/bp-messages-single-load-more.php
+++ b/buddypress/common/js-templates/messages/parts/bp-messages-single-load-more.php
@@ -1,0 +1,3 @@
+<script type="text/html" id="tmpl-bp-messages-single-load-more">
+	<button type="button" class="button" style="display: none;"><i class="dashicons dashicons-update animate-spin"></i><?php _e( 'Load previous messages', 'buddyboss' ); ?></button>
+</script>

--- a/buddypress/common/js-templates/messages/parts/bp-messages-single.php
+++ b/buddypress/common/js-templates/messages/parts/bp-messages-single.php
@@ -1,0 +1,50 @@
+<script type="text/html" id="tmpl-bp-messages-single">
+	<?php bp_nouveau_messages_hook( 'before', 'thread_content' ); ?>
+
+	<div id="bp-message-thread-header" class="message-thread-header"></div>
+	<div id="bp-message-load-more"></div>
+	<div class="bp-messages-feedback"></div>
+
+	<?php bp_nouveau_messages_hook( 'before', 'thread_list' ); ?>
+
+	<ul id="bp-message-thread-list"></ul>
+
+	<?php bp_nouveau_messages_hook( 'after', 'thread_list' ); ?>
+
+	<?php bp_nouveau_messages_hook( 'before', 'thread_reply' ); ?>
+
+	<form id="send-reply" class="standard-form send-reply">
+		<div class="message-box">
+			<div class="message-metadata">
+
+				<?php bp_nouveau_messages_hook( 'before', 'reply_meta' ); ?>
+
+				<div class="avatar-box">
+					<strong><?php esc_html_e( 'Send a Reply', 'buddyboss' ); ?></strong>
+				</div>
+
+				<?php bp_nouveau_messages_hook( 'after', 'reply_meta' ); ?>
+
+			</div><!-- .message-metadata -->
+
+			<div class="bp-message-content-wrap">
+
+				<?php bp_nouveau_messages_hook( 'before', 'reply_box' ); ?>
+
+				<label for="message_content" class="bp-screen-reader-text"><?php _e( 'Reply to Message', 'buddyboss' ); ?></label>
+				<div id="bp-message-content"></div>
+
+				<?php bp_nouveau_messages_hook( 'after', 'reply_box' ); ?>
+
+			</div><!-- .message-content -->
+
+		</div><!-- .message-box -->
+	</form>
+
+	<?php bp_nouveau_messages_hook( 'after', 'thread_reply' ); ?>
+
+	<?php bp_nouveau_messages_hook( 'after', 'thread_content' ); ?>
+</script>
+<script type="text/html" id="tmpl-bp-messages-reply-form-submit">
+    <input type="submit" name="send" value="<?php esc_attr_e( 'Send Reply', 'buddyboss' ); ?>" id="send_reply_button" class="small" />
+</script>

--- a/buddypress/common/js-templates/messages/parts/bp-messages-thread.php
+++ b/buddypress/common/js-templates/messages/parts/bp-messages-thread.php
@@ -1,0 +1,88 @@
+<script type="text/html" id="tmpl-bp-messages-thread">
+	<#
+	var other_recipients = _.reject(data.recipients, function(item) {
+	return item.is_you;
+	});
+
+	var current_user = _.find(data.recipients, function(item) {
+	return item.is_you;
+	});
+
+	var include_you = other_recipients.length >= 2;
+	var first_three = _.first(other_recipients, 3);
+
+	if (first_three.length == 0) {
+	include_you = true;
+	}
+	#>
+
+	<# if ( ! data.is_search ) { #>
+	<a href="javascript:void(0);" data-bp-thread-id="{{data.id}}" data-bp-action="hide_thread" class="close-conversation"> <i class="dashicons dashicons-no-alt"></i> </a>
+	<# } #>
+	<a class="bp-message-link bp-message-link-{{data.id}}" href="../view/{{data.id}}/" data-thread-id="{{data.id}}">
+		<div class="thread-avatar {{ ( data.is_user_suspended || data.is_user_blocked ) && ! data.is_group_thread ? 'bp-suspended-avatar' : '' }}">
+            <# if ( data.avatars && data.avatars.length > 1  ) {
+                if( data.avatars.length == 2 ) { #>
+                    <div class="thread-multiple-avatar">
+                <# } #>
+                    <img class="avatar" src="{{{data.avatars[0].url}}}" alt="{{data.avatars[0].name}}"/>
+                    <# if( data.avatars[1] ) { #>
+                        <img class="avatar" src="{{{data.avatars[1].url}}}" alt="{{data.avatars[1].name}}"/>
+                    <# }
+                if( data.avatars.length == 2 ) { #>
+                    </div>
+                <# } #>
+            <# } else if ( data.group_avatar && data.group_avatar.length > 1 && data.is_group_thread ) { #>
+				<img class="avatar" src="{{{data.group_avatar}}}" alt="{{data.group_name}}" />
+			<# } else { #>
+				<# if ( other_recipients.length > 1 ) { #>
+					<span class="recipients-count">{{other_recipients.length}}</span>
+					<img class="avatar" src="{{{data.sender_avatar}}}" alt="{{data.sender_name}}" />
+				<# } else { #>
+					<# var recipient = _.first(other_recipients)? _.first(other_recipients) : current_user; #>
+					<# if ( typeof( recipient ) != "undefined" && recipient !== null && recipient.avatar.length > 1 && recipient.user_name.length > 1 ) { #>
+						<img class="avatar" src="{{{recipient.avatar}}}" alt="{{recipient.user_name}}" />
+					<# } #>
+				<# } #>
+			<# } #>
+		</div>
+
+		<div class="thread-content {{ ( data.is_user_suspended || data.is_user_blocked ) && ! data.is_group_thread ? 'bp-suspended-content' : '' }}" data-thread-id="{{data.id}}">
+			<div class="thread-to">
+
+				<# if ( data.group_name && data.group_name.length && data.is_group_thread ) { #>
+				    <span class="user-name">{{data.group_name}}</span>
+                <# } else { #>
+                <# for ( i in first_three ) { #>
+                    <span class="user-name">{{other_recipients[i].user_name}}<# if ( i != first_three.length - 1  || ( i == first_three.length -1 && data.toOthers ) ) { #><?php _e( ',', 'buddyboss' ); ?><# } #></span>
+                <# } #>
+                <# if ( data.toOthers ) { #>
+				<span class="num-name">{{data.toOthers}}</span>
+                <# } #>
+
+				<# } #>
+			</div>
+
+            <# if ( ! data.is_user_suspended && ! data.is_user_blocked ) { #>
+			<div class="thread-subject">
+				<span class="last-message-sender">
+				  <# if ( data.sender_is_you ) { #>
+					<?php _e( 'You', 'buddyboss' ); ?>:
+				  <# } else { #>
+					{{ data.sender_name }}:
+				  <# } #>
+				</span>
+                {{{data.excerpt}}}
+			</div>
+			<# } #>
+				
+				
+
+
+		</div>
+
+		<div class="thread-date">
+			<time datetime="{{data.date.toISOString()}}">{{data.display_date}}</time>
+		</div>
+	</a>
+</script>

--- a/buddypress/common/js-templates/messages/search-form.php
+++ b/buddypress/common/js-templates/messages/search-form.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * BP Nouveau Messages search form template.
+ *
+ * @since BuddyPress 3.2.0
+ */
+?>
+<form action="" method="get" id="user_messages_search_form" class="bp-messages-search-form" data-bp-search="messages">
+	<button type="submit" id="user_messages_search_submit">
+		<span class="bb-icon-search" aria-hidden="true"></span>
+		<span class="bp-screen-reader-text"><?php esc_html_e( 'Search', 'buddyboss' ); ?></span>
+	</button>
+	<label for="user_messages_search" class="bp-screen-reader-text">
+		<?php _e( 'Search Messages', 'buddyboss' ); ?>
+	</label>
+	<input type="search" id="user_messages_search" placeholder="<?php esc_attr_e( 'Search Messages', 'buddyboss' ); ?>"/>
+</form>

--- a/buddypress/common/search-and-filters-bar.php
+++ b/buddypress/common/search-and-filters-bar.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * BP Nouveau Search & filters bar
+ *
+ * @since BuddyPress 3.0.0
+ * @version 3.1.0
+ */
+?>
+<div class="subnav-filters filters no-ajax" id="subnav-filters">
+
+	<?php if ( 'friends' !== bp_current_component() ) : ?>
+
+        <?php if ( 'members' !== bp_current_component() || bp_disable_advanced_profile_search() ) : ?>
+            <div class="subnav-search clearfix">
+
+                <?php bp_nouveau_search_form(); ?>
+
+            </div>
+        <?php endif; ?>
+
+	<?php endif; ?>
+    
+    <?php if ( ( 'members' === bp_current_component() || 'groups' === bp_current_component() || 'friends' === bp_current_component() ) && ! bp_is_current_action( 'requests' ) ): ?>
+        <?php bp_get_template_part( 'common/filters/grid-filters' ); ?>
+    <?php endif; ?>
+
+	<?php if ( bp_is_user() && ( ! bp_is_current_action( 'requests' ) && ! bp_is_current_action( 'mutual' ) ) ): ?>
+		<?php bp_get_template_part( 'common/filters/directory-filters' ); ?>
+	<?php endif; ?>
+
+    <?php if ( 'members' === bp_current_component() || ( 'friends' === bp_current_component() && 'my-friends' === bp_current_action() ) ): ?>
+        <?php bp_get_template_part( 'common/filters/member-filters' ); ?>
+    <?php endif; ?>
+
+	<?php if ( 'groups' === bp_current_component() ): ?>
+		<?php bp_get_template_part( 'common/filters/group-filters' ); ?>
+	<?php endif; ?>
+
+</div><!-- search & filters -->

--- a/functions.php
+++ b/functions.php
@@ -72,7 +72,6 @@ function bfc_avatar_dropdown ($type,$source,$follow_class){
   if ($type == 'reply-author') {
     $person = bbp_get_reply_author_id($source);
   }
-  $output = '<script> jQuery(document).foundation() </script>';
   $output .= '<div class="dropdown-pane '. $follow_class . '" id="' . $type . '-dropdown-' . esc_attr( $source ) . '" data-dropdown data-hover="true" data-hover-pane="true" data-auto-focus="false">';
   if($person != $user) {
     $output .= '<a href="/members/' . bp_core_get_username($user) . '/messages/compose/?r=' . bp_core_get_username($person) . '">Send a message</a><br>';


### PR DESCRIPTION
Turns out that including the initialization of Foundation in `bfc_avatar_dropdown()` wasn't so clever as I thought. The console gave me lots of warnings that doing so meant multiple initialization attempts on the same page. So I've taken `jQuery(document).foundation();` out of `bfc_avatar_dropdown()` and put it into the template `bbpress/loop-replies.php`. No more warnings in the console.