### PR TITLE
Bringing the child theme into sync with buddyboss-theme 1.7.0

### DIFF
--- a/bbpress/loop-replies.php
+++ b/bbpress/loop-replies.php
@@ -186,22 +186,6 @@
 
 </ul><!-- #topic-<?php bbp_topic_id(); ?>-replies -->
 
-<div class="single-topic-sidebar-links">
-	<p class="bb-topic-reply-link-wrap"><?php bbp_topic_reply_link(); ?></p>
-	<p class="bb-topic-subscription-link-wrap"><?php $args = array('before' => '');
-	echo bbp_get_topic_subscription_link( $args ); ?></p>
-	<?php
-	if ( bp_is_active( 'moderation' ) && function_exists( 'bbp_get_topic_report_link' ) ) {
-		?>
-		<p  class="bb-topic-report-link-wrap">
-			<?php
-			echo bbp_get_topic_report_link( array( 'id' => get_the_ID() ) );
-			?>
-		</p>
-	<?php
-	}
-	?>
-</div>
 <script> 
 	jQuery(document).foundation();
 </script>


### PR DESCRIPTION
BuddyBoss is currently pushing out frequent updates. Comparing 1.7.0 with brightfuturecommons revealed an earlier error I had made in bbpress/loop-replies.php. I had copied irrelevant code from bbpress/content-single-topic.php when I was moving jQuery(document).foundation() from that file to loop-replies.php. I've now removed the misplaced code.