### PR TITLE
Customizing the Activity widget for the User Dashboard

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -290,9 +290,10 @@ nav#object-nav li.bfc-group-name-nav{
 .bfc-la-li {
 	display: grid;
 	grid-template-columns: 46px 1fr;
-	margin-top: 0;
+	margin-bottom: 10px;
 	padding-top: 10px;
-	border: 1px solid #eeeeee;
+	padding-bottom: 10px;
+	border-bottom: 1px solid #eaeaea;
 }
 
 .bfc-la-ul {
@@ -392,3 +393,36 @@ nav#object-nav li.bfc-group-name-nav{
 	}
 
 }
+
+
+.bfc-user-panel .activity-update cite::before {
+	content: none;
+}
+
+.bfc-user-panel .activity-list {
+	padding: 0px;
+}
+
+.bfc-user-panel .activity-update .update-item {
+	display: grid;
+    grid-template-columns: 46px 1fr;
+	margin-top: 22px;
+}
+
+.bfc-user-panel .activity-content {
+	/* margin-left: 46px; */	
+	font-size: 13px;
+	margin-bottom: 24px;
+	/* padding-bottom: 10px; */
+	border-bottom: 1px solid #eaeaea;
+
+}
+
+.bfc-user-panel .activity-inner {
+	word-break: break-word;
+}
+
+.bfc-user-panel .activity-inner p {
+	margin-bottom: 10px;
+}
+

--- a/buddypress/activity/widget.php
+++ b/buddypress/activity/widget.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * BP Nouveau Activity Widget template.
+ *
+ * @since BuddyPress 3.0.0
+ * @version 3.0.0
+ */
+?>
+
+<?php if ( bp_has_activities( bp_nouveau_activity_widget_query() ) ) : ?>
+
+	<div class="activity-list item-list">
+
+		<?php
+		while ( bp_activities() ) :
+			bp_the_activity();
+		?>
+
+		<div class="activity-update">
+
+			<div class="update-item">
+
+				<cite>
+					<a href="<?php bp_activity_user_link(); ?>" class="bp-tooltip" data-bp-tooltip-pos="up" data-bp-tooltip="<?php echo esc_attr( bp_activity_member_display_name() ); ?>">
+						<?php
+						bp_activity_avatar(
+							array(
+								'type'   => 'thumb',
+								'width'  => '40',
+								'height' => '40',
+							)
+						);
+						?>
+					</a>
+				</cite>
+
+				<div class="bp-activity-info">
+					<?php bp_activity_action(); ?>
+				</div>
+			</div>
+
+		</div>
+
+		<?php endwhile; ?>
+
+	</div>
+
+<?php else : ?>
+
+	<div class="widget-error">
+		<?php bp_nouveau_user_feedback( 'activity-loop-none' ); ?>
+	</div>
+
+<?php endif; ?>

--- a/buddypress/activity/widget.php
+++ b/buddypress/activity/widget.php
@@ -1,6 +1,7 @@
 <?php
 /**
- * BP Nouveau Activity Widget template.
+ * BFC Activity Widget template.
+ * Adapted from BP Nouveau Activity Widget template.
  *
  * @since BuddyPress 3.0.0
  * @version 3.0.0
@@ -15,7 +16,7 @@
 		while ( bp_activities() ) :
 			bp_the_activity();
 		?>
-
+		<?php if ( bp_activity_has_content() ) : ?>
 		<div class="activity-update">
 
 			<div class="update-item">
@@ -40,6 +41,19 @@
 			</div>
 
 		</div>
+		<div class="activity-content <?php ( function_exists('bp_activity_entry_css_class') ) ? bp_activity_entry_css_class(): ''; ?>">
+		
+			<div class="activity-inner <?php echo ( function_exists( 'bp_activity_has_content' ) && empty( bp_activity_has_content() ) ) ? esc_attr( 'bb-empty-content' ) : esc_attr( '' ); ?>">
+				<?php
+					add_filter('bp_activity_excerpt_length','bfc_activity_widget_excerpt_length',900);
+					bp_nouveau_activity_content();
+					remove_filter('bp_activity_excerpt_length','bfc_activity_widget_excerpt_length',900);
+				?>
+			</div>
+
+		</div>
+
+		<?php endif; ?>
 
 		<?php endwhile; ?>
 

--- a/functions/widgets.php
+++ b/functions/widgets.php
@@ -442,4 +442,24 @@ class bsp_Activity_Widget extends WP_Widget {
 	}
 }
 
+/**
+ * For the User Dashboard
+ */
+function bfc_activity_widget_excerpt_length(){
+	$excerpt_length = 150;
+	return (int) $excerpt_length;
+}
 
+
+
+/**
+ * A filter to simplify the output from bp_activity_action() in the Activty widget on the User Dashboard
+ */
+
+function bfc_simplify_activity_action ($action){
+	$action = str_replace(' posted an update','<br>', $action );
+	$action = 'From ' . $action;
+	return $action;
+}
+
+add_filter( 'bp_get_activity_action_pre_meta', 'bfc_simplify_activity_action', 10, 1);


### PR DESCRIPTION
BuddyBoss has a widget called (BB) Latest Activities that inherits a lot from a similar BuddyPress widget. I've used that widget as a starting point for a widget that we can use to display a selected set of latest activities on the User Dashboard.

After a fair bit of reverse engineering, I found that I could do all that I wanted by modifying three files:
- buddypress/activity/widget.php – This is the display template for the widget and our child-theme version overrides the standard version.
- functions/widgets.php – I've put two associated functions in this file. This starts a practice of putting widget-associated functions as well as widget definitions into this file.
- assets/css/custom.css – For the layout and look.

My Admin settings are under Appearance > Widgets > User Home Center Panel > (BB) Latest Activities
- Title: **Updates**
- Maximum amount to display: **6**
- Activity Type: **Updates, New Groups, Group Updates**