### PR TITLE
Move post actions control to end of the post

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -103,6 +103,25 @@ nav#object-nav li.bfc-group-name-nav{
 .bs-forum-content .bbp-topic-revision-log, .bs-forum-content .bbp-reply-revision-log{
 	display: none;
 }
+
+#bbpress-forums#bbpress-forums .bs-forums-items.list-view .bs-dropdown-wrap .bs-dropdown-wrap-inner>a {
+	float: right;
+}
+
+#bbpress-forums div.bbp-reply-content ul li, #bbpress-forums div.bbp-topic-content ul li {
+    list-style-type: none;
+}
+
+.bs-dropdown {
+	min-width: 100px;
+ }
+ 
+ #bbpress-forums#bbpress-forums .bs-forums-items.list-view .bs-dropdown-wrap .bs-dropdown-wrap-inner .bs-dropdown {
+   width: 100px;
+}
+
+
+
 /* dropdown pane */
 
 #buddypress .bb-grid  .dropdown-pane .generic-button, #buddypress .bp-list  .dropdown-pane .generic-button {

--- a/bbpress/loop-single-reply.php
+++ b/bbpress/loop-single-reply.php
@@ -52,12 +52,25 @@ $follow_class = $is_follow_active ? 'follow-active' : '';
 		</div><!-- .bbp-reply-author -->
 
 
+
+	</div>
+
+	<div class="bbp-after-author-hook">
+		<?php do_action( 'bbp_theme_after_reply_author_details' ); ?>
+	</div>
+
+	<div class="bbp-reply-content bs-forum-content">
+
+		<?php do_action( 'bbp_theme_before_reply_content' ); ?>
+
+		<?php bbp_reply_content(); ?>
+
 		<?php
 		/**
 		 * Checked bbp_get_reply_admin_links() is empty or not if links not return then munu dropdown will not show
 		 */
 		if ( is_user_logged_in() && ! empty( strip_tags( bbp_get_reply_admin_links() ) ) ) { ?>
-            <!-- <div class="bbp-meta push-right">
+            <div class="bbp-meta push-right">
                 <div class="more-actions bb-reply-actions bs-dropdown-wrap align-self-center">
 					<?php
 					$empty       = false;
@@ -113,16 +126,16 @@ $follow_class = $is_follow_active ? 'follow-active' : '';
                     <div class="bs-dropdown-wrap-inner <?php echo esc_attr( $parent_class ); ?>">
 						<?php
 						// If post is a topic, print the topic admin links instead.
-						if ( bbp_is_topic( bbp_get_reply_id() ) ) {
-							add_filter( 'bbp_get_topic_reply_link', 'bb_theme_topic_link_attribute_change', 9999, 3 );
-							echo bbp_get_topic_reply_link();
-							remove_filter( 'bbp_get_topic_reply_link', 'bb_theme_topic_link_attribute_change', 9999, 3 );
-							// If post is a reply, print the reply admin links instead.
-						} else {
-							add_filter( 'bbp_get_reply_to_link', 'bb_theme_reply_link_attribute_change', 9999, 3 );
-							echo bbp_get_reply_to_link();
-							remove_filter( 'bbp_get_reply_to_link', 'bb_theme_reply_link_attribute_change', 9999, 3 );
-						}
+						// if ( bbp_is_topic( bbp_get_reply_id() ) ) {
+						// 	add_filter( 'bbp_get_topic_reply_link', 'bb_theme_topic_link_attribute_change', 9999, 3 );
+						// 	echo bbp_get_topic_reply_link();
+						// 	remove_filter( 'bbp_get_topic_reply_link', 'bb_theme_topic_link_attribute_change', 9999, 3 );
+						// 	// If post is a reply, print the reply admin links instead.
+						// } else {
+						// 	add_filter( 'bbp_get_reply_to_link', 'bb_theme_reply_link_attribute_change', 9999, 3 );
+						// 	echo bbp_get_reply_to_link();
+						// 	remove_filter( 'bbp_get_reply_to_link', 'bb_theme_reply_link_attribute_change', 9999, 3 );
+						// }
 						if ( ! $empty ) {
 							?>
                             <a href="#" class="bs-dropdown-link bb-reply-actions-button" data-balloon-pos="up"
@@ -143,20 +156,9 @@ $follow_class = $is_follow_active ? 'follow-active' : '';
 						?>
                     </div>
                 </div>
-            </div> -->
+            </div>
 		<?php } ?>
 
-	</div>
-
-	<div class="bbp-after-author-hook">
-		<?php do_action( 'bbp_theme_after_reply_author_details' ); ?>
-	</div>
-
-	<div class="bbp-reply-content bs-forum-content">
-
-		<?php do_action( 'bbp_theme_before_reply_content' ); ?>
-
-		<?php bbp_reply_content(); ?>
 
 		<?php do_action( 'bbp_theme_after_reply_content' ); ?>
 


### PR DESCRIPTION
Addresses issue #8

I've removed the "reply" button since a similar feature in Xenforo was always confusing to users. You can't reply directly to a post in the middle of a thread. Better to read the whole thread, quote from a post if you like, and put your reply at the end.

We should consider whether to have the three vertical dots normally visible or only visible on hover.