### PR TITLE
CSS fixes - see description

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -26,14 +26,14 @@ body {
 .notification-avatar img, .user-link img{
 	border-radius:20%;
 	}
-#friend-list.item-list .item-avatar img,#members-list.item-list .item-avatar img{
+#friend-list.item-list .item-avatar img, #members-list.item-list .item-avatar img{
 	border-radius:20%;
 	}
 #bbpress-forums#bbpress-forums .bs-forums-items .item-avatar img{
 	border-radius:20%;
 	max-width: 80px;
 	}
-.avatar{
+.entry-content-wrap .avatar, .avatar{
 	border-radius:20%;
 	}
 body #buddypress:not(.round-avatars) .groups-header #item-header-cover-image #item-header-avatar img.avatar{
@@ -52,6 +52,10 @@ body #buddypress:not(.round-avatars) .users-header #item-header-cover-image #ite
 	height:14px;
 	}
 
+.comment-author .avatar {
+	border-radius: 20%;
+	max-width: 42px;
+	}
 /* Groups */
 
 .single-item.groups .content-area {
@@ -85,7 +89,7 @@ nav#object-nav li.bfc-group-name-nav{
 #bbpress-forums h1.bb-reply-topic-title {
 	font-size: 28px;
 }
-#bbpress-forums#bbpress-forums .bs-forums-items .item-avatar {
+#bbpress-forums#bbpress-forums .bs-forums-items .bbp-reply-author .item-avatar {
 	margin: auto;
 	padding-bottom: 5px;
 }
@@ -99,6 +103,7 @@ nav#object-nav li.bfc-group-name-nav{
 	font-family: charter, Georgia, Cambria, "Times New Roman", Times, serif;
 	font-size: 17px;
 	line-height: 1.6;
+	flex-grow: 1;
 }
 .bs-forum-content .bbp-topic-revision-log, .bs-forum-content .bbp-reply-revision-log{
 	display: none;
@@ -108,8 +113,8 @@ nav#object-nav li.bfc-group-name-nav{
 	float: right;
 }
 
-#bbpress-forums div.bbp-reply-content ul li, #bbpress-forums div.bbp-topic-content ul li {
-    list-style-type: none;
+#bbpress-forums div.bbp-reply-content ul.bs-dropdown li, #bbpress-forums div.bbp-topic-content ul.bs-dropdown li {
+	list-style-type: none;
 }
 
 .bs-dropdown {


### PR DESCRIPTION
line 36 - add selector for blog author avatars
line 55 - add css for blog commentor avatars
line 92 - fix selector so that only avatars in threads have margin:auto
This fixes #24
line 106 - makes sure the admin actions (3 dots) line up in the lower right of posts even when the post content is less than a single line.
line 116 - fix selector so the LI marker is only removed from the admin actions dropdown