### PR TITLE
For the groups directory page

### DIFF
--- a/buddypress/groups/groups-loop.php
+++ b/buddypress/groups/groups-loop.php
@@ -96,6 +96,16 @@ bp_nouveau_before_loop(); ?>
 
 	</ul>
 
+	<script>
+		if ( document.getElementById("groups-personal").classList.contains('selected') ){
+			document.getElementById("groups-dir-list").classList.add("my-groups");
+			document.getElementById("groups-dir-list").classList.remove("other-groups");
+		} else if ( document.getElementById("groups-others").classList.contains('selected') ){
+			document.getElementById("groups-dir-list").classList.add("other-groups");
+			document.getElementById("groups-dir-list").classList.remove("my-groups");
+		} 
+	</script>
+
 	<?php bp_nouveau_pagination( 'bottom' ); ?>
 
 <?php else : ?>

--- a/buddypress/groups/groups-loop.php
+++ b/buddypress/groups/groups-loop.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * BuddyBoss - Groups Loop
+ *
+ * @since BuddyPress 3.0.0
+ * @version 3.1.0
+ */
+
+bp_nouveau_before_loop(); ?>
+
+<?php if ( bp_get_current_group_directory_type() ) : ?>
+    <div class="bp-feedback info">
+    <span class="bp-icon" aria-hidden="true"></span>
+	<p class="current-group-type"><?php bp_current_group_directory_type_message(); ?></p>
+    </div>
+<?php endif; ?>
+
+<?php $cover_class = bp_disable_group_cover_image_uploads() ? 'bb-cover-disabled' : 'bb-cover-enabled'; ?>
+
+<?php if ( bp_has_groups( bp_ajax_querystring( 'groups' ) ) ) : ?>
+
+	<?php bp_nouveau_pagination( 'top' ); ?>
+
+	<ul id="groups-list" class="<?php bp_nouveau_loop_classes(); ?> <?php echo $cover_class; ?>">
+
+	<?php
+	while ( bp_groups() ) :
+		bp_the_group();
+	?>
+
+		<li <?php bp_group_class( array( 'item-entry' ) ); ?> data-bp-item-id="<?php bp_group_id(); ?>" data-bp-item-component="groups">
+			<div class="list-wrap">
+
+				<?php if( !bp_disable_group_cover_image_uploads() ) { ?>
+					<?php
+					$group_cover_image_url = bp_attachments_get_attachment( 'url', array(
+						'object_dir' => 'groups',
+						'item_id'    => bp_get_group_id(),
+					) );
+					$default_group_cover   = buddyboss_theme_get_option( 'buddyboss_group_cover_default', 'url' );
+					$group_cover_image_url = $group_cover_image_url ?: $default_group_cover;
+					?>
+					<div class="bs-group-cover only-grid-view"><a href="<?php bp_group_permalink(); ?>"><img src="<?php echo $group_cover_image_url; ?>"></a></div>
+				<?php } ?>
+
+				<?php if ( ! bp_disable_group_avatar_uploads() ) : ?>
+					<div class="item-avatar">
+						<a href="<?php bp_group_permalink(); ?>" class="group-avatar-wrap"><?php bp_group_avatar( bp_nouveau_avatar_args() ); ?></a>
+
+						<div class="groups-loop-buttons only-grid-view">
+							<?php bp_nouveau_groups_loop_buttons(); ?>
+						</div>
+					</div>
+				<?php endif; ?>
+
+				<div class="item">
+					<div class="item-block">
+
+						<h2 class="list-title groups-title"><?php bp_group_link(); ?></h2>
+
+						<?php if ( bp_nouveau_group_has_meta() ) : ?>
+
+							<p class="item-meta group-details only-list-view"><?php bp_nouveau_group_meta(); ?></p>
+							<p class="item-meta group-details only-grid-view"><?php
+								$meta = bp_nouveau_get_group_meta();
+								echo $meta['status']; ?>
+							</p>
+						<?php endif; ?>
+
+						<p class="last-activity item-meta">
+							<?php
+							printf(
+								/* translators: %s = last activity timestamp (e.g. "active 1 hour ago") */
+								__( 'active %s', 'buddyboss-theme' ),
+								bp_get_group_last_active()
+							);
+							?>
+						</p>
+
+					</div>
+
+					<div class="item-desc group-item-desc only-list-view"><?php bp_group_description_excerpt( false , 250 ) ?></div>
+
+					<?php bp_nouveau_groups_loop_item(); ?>
+
+					<div class="groups-loop-buttons footer-button-wrap"><?php bp_nouveau_groups_loop_buttons(); ?></div>
+
+					<div class="group-members-wrap only-grid-view">
+						<?php echo buddyboss_theme()->buddypress_helper()->group_members( bp_get_group_id(), array( 'member', 'mod', 'admin' ) ); ?>
+					</div>
+				</div>
+			</div>
+		</li>
+
+	<?php endwhile; ?>
+
+	</ul>
+
+	<?php bp_nouveau_pagination( 'bottom' ); ?>
+
+<?php else : ?>
+
+	<?php bp_nouveau_user_feedback( 'groups-loop-none' ); ?>
+
+<?php endif; ?>
+
+<?php
+bp_nouveau_after_loop();

--- a/functions/bfc-functions.php
+++ b/functions/bfc-functions.php
@@ -243,13 +243,17 @@ function bfc_custom_group_args ( $qs, $object ) {
     return $qs;
   }
 
+  $groupids = BP_Groups_Member::get_group_ids( get_current_user_id());
+
   $args = wp_parse_args( $qs );
 
+  if ( !isset ($args['scope'])) {
+	$args['scope'] = 'personal';
+	$args['include'] = $groupids['groups'];
+  }
+
   if ( $args['scope'] === 'others' ) { // You can change the scope value
-
-    $groupids = BP_Groups_Member::get_group_ids( get_current_user_id());
-    $args['exclude'] = $groupids['groups'];
-
+	$args['exclude'] = $groupids['groups'];
   } 
   $qs = build_query( $args );
 


### PR DESCRIPTION
Two items:
1) With the help of Query Monitor plus sleeping on it, I was able to resolve the issue of first page load on the groups directory showing all groups under the My Groups tab rather than just the user's groups. We now (finally!) have the behavior I want on the groups directory page.

2) I created a simple bit of JS in groups-loop.php so that we can have different categories of content displayed under My Groups and under Other Groups. I plan on implementing this with appropriate use of display: hidden in the css.