### PR TITLE
Fix for Other Groups for new users

### DIFF
--- a/buddypress/groups/index.php
+++ b/buddypress/groups/index.php
@@ -33,10 +33,15 @@
 			<?php bp_get_template_part( 'common/filters/grid-filters' ); ?>
 		</div>
 	</div>
+	<?php
+	$tab = 'my-groups';
+	if ( bp_get_total_group_count_for_user( bp_loggedin_user_id() ) == 0 ) {
+		$tab = 'other-groups';
+	} ?>
 
 	<div class="screen-content">
 
-		<div id="groups-dir-list" class="groups dir-list" data-bp-list="groups">
+		<div id="groups-dir-list" class="groups dir-list <?php echo $tab; ?>" data-bp-list="groups">
 			<div id="bp-ajax-loader"><?php bp_nouveau_user_feedback( 'directory-groups-loading' ); ?></div>
 		</div><!-- #groups-dir-list -->
 

--- a/functions/bfc-functions.php
+++ b/functions/bfc-functions.php
@@ -254,8 +254,12 @@ function bfc_custom_group_args ( $qs, $object ) {
   $args = wp_parse_args( $qs );
 
   if ( !isset ($args['scope'])) {
-	$args['scope'] = 'personal';
-	$args['include'] = $groupids['groups'];
+	if ( bp_get_total_group_count_for_user( bp_loggedin_user_id() ) >0 ) {
+		$args['scope'] = 'personal';
+		$args['include'] = $groupids['groups'];
+	} else {
+		$args['scope'] = 'other';
+	}
   }
 
   if ( $args['scope'] === 'others' ) { // You can change the scope value


### PR DESCRIPTION
These tweaks get the Other Groups tab to display properly for a user who is not a member of any group.