### PR TITLE
Fix for mobile dashboard accordion.

### DIFF
--- a/functions/widgets.php
+++ b/functions/widgets.php
@@ -576,9 +576,6 @@ class bfc_messages_widget extends WP_Widget {
 		}
 		echo $args['after_widget']; ?>
 		</div>
-		<script>
-			jQuery(document).foundation();
-		</script>
 	<?php }
 			  
 	// Creating widget Backend 

--- a/homepage.php
+++ b/homepage.php
@@ -43,32 +43,32 @@ get_header(); ?>
 				<?php endif; ?>
 			</div>
 
-			<div id="bfc-user-accordion" class="bfc-user-accordion accordion" data-accordion data-allow-all-closed="true">
-				<?php $bfc_dropdown_prefix = 'ac';?>
+			<?php $bfc_dropdown_prefix = 'ac';?>
+			<ul id="bfc-user-accordion" class="bfc-user-accordion accordion" data-accordion data-allow-all-closed="true">
 				<?php if ( is_active_sidebar( 'user_left_panel' ) ) : ?>
-					<div id="bfc-user-panel-top" class="bfc-user-panel-top widget-area" data-accordion-item>
+					<li class="accordion-item bfc-user-panel-top widget-area" data-accordion-item >
 					<a href="#" class="accordion-title">Latest Updates</a>
 					<div class="accordion-content" data-tab-content>
 						<?php dynamic_sidebar( 'user_left_panel' ); ?>
-					</div></div><!-- #bfc-user-panel-le-top -->
+					</div></li><!-- #bfc-user-panel-le-top -->
 
 				<?php endif; ?>
 				<?php if ( is_active_sidebar( 'user_center_panel' ) ) : ?>
-					<div id="bfc-user-panel-middle" class="bfc-user-panel-middle widget-area" data-accordion-item>
+					<li class="accordion-item bfc-user-panel-middle widget-area" data-accordion-item >
 					<a href="#" class="accordion-title">Forum Posts</a>
 					<div class="accordion-content" data-tab-content>
 						<?php dynamic_sidebar( 'user_center_panel' ); ?>
-					</div></div><!-- #bfc-user-panel-middle -->
+					</div></li><!-- #bfc-user-panel-middle -->
 				<?php endif; ?>
 
 				<?php if ( is_active_sidebar( 'user_right_panel' ) ) : ?>
-					<div id="bfc-user-panel-bottom" class="bfc-user-panel-bottom widget-area" data-accordion-item>
+					<li class="accordion-item bfc-user-panel-bottom widget-area" data-accordion-item >
 					<a href="#" class="accordion-title">Blog Posts</a>
 					<div class="accordion-content" data-tab-content>
 						<?php dynamic_sidebar( 'user_right_panel' ); ?>
-					</div></div><!-- #bfc-user-panel-bottom -->
+					</div></li><!-- #bfc-user-panel-bottom -->
 				<?php endif; ?>
-			</div>
+				</ul>
 
 			</div>
 


### PR DESCRIPTION
For mobile screens, the dashboard switches to an accordion. It worked at one point in the past but while working on the widescreen view, I noticed that only the first panel of the accordion would open. Turns out that I had put a `jQuery(document).foundation();`in the widget for the first panel, which reset everything and kept the other two from initializing. With that removed, it's working again.