### PR TITLE
Creating an activity widget for dashboards + misc cleanup

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -494,21 +494,23 @@ nav#object-nav li.bfc-group-name-nav{
 	position:relative;
 }
 
-#forums-notification-settings {
-	display: none;
-}
 .other-groups #groups-list .bfc-group-latest-post,
-.my-groups #groups-list .group-details,
 .my-groups #groups-list .item-desc.group-item-desc,
 .my-groups #groups-list .group-members-wrap,
 #buddypress .my-groups .bp-list .action .generic-button .group-button, 
-.mygroups #groups-list .group-details,
 .mygroups #groups-list .item-desc.group-item-desc,
 .mygroups #groups-list .group-members-wrap,
 #buddypress .mygroups .bp-list .action .generic-button .group-button {
 	display: none;
 }
 
+#groups-list.bp-list:not(.grid)  {
+	flex-wrap: wrap;
+}
+
+#groups-list .item-entry {
+	flex-grow: 1;
+}
 .my-groups #groups-list .bfc-group-latest-post,
 .mygroups #groups-list .bfc-group-latest-post {
 	flex-grow: 1;

--- a/bbpress/content-single-topic.php
+++ b/bbpress/content-single-topic.php
@@ -41,7 +41,14 @@
 
 				<?php endif; ?>
 
-				<p class="bb-topic-reply-link-wrap mobile-only"><?php bbp_topic_reply_link(); ?></p>
+				<p class="bb-topic-reply-link-wrap mobile-only">
+					<?php
+					bbp_topic_reply_link();
+					if ( ! bbp_current_user_can_access_create_reply_form() && ! bbp_is_topic_closed() && ! bbp_is_forum_closed( bbp_get_topic_forum_id() ) && ! is_user_logged_in() ) {
+						?>
+						<a href="<?php echo esc_url( wp_login_url() ); ?>" class="bbp-topic-login-link bb-style-primary-bgr-color bb-style-border-radius"><?php esc_html_e( 'Log In to Reply', 'buddyboss-theme' ); ?></a>
+					<?php } ?>
+				</p>
 				<p class="bb-topic-subscription-link-wrap mobile-only">
 					<?php
 					$args = array( 'before' => '' );
@@ -60,7 +67,14 @@
 		<!-- <div class="bb-sm-grid bs-single-topic-sidebar">
             <div class="bs-topic-sidebar-inner"> -->
 				<div class="single-topic-sidebar-links">
-					<!-- <p class="bb-topic-reply-link-wrap"><?php bbp_topic_reply_link(); ?></p> -->
+					<!--<p class="bb-topic-reply-link-wrap">
+						<?php
+						bbp_topic_reply_link();
+						if ( ! bbp_current_user_can_access_create_reply_form() && ! bbp_is_topic_closed() && ! bbp_is_forum_closed( bbp_get_topic_forum_id() ) && ! is_user_logged_in() ) {
+							?>
+							<a href="<?php echo esc_url( wp_login_url() ); ?>" class="bbp-topic-login-link bb-style-primary-bgr-color bb-style-border-radius"><?php esc_html_e( 'Log In to Reply', 'buddyboss-theme' ); ?></a>
+						<?php } ?>
+					</p> -->
 					<p class="bb-topic-subscription-link-wrap">
 					<?php
 					// $args = array( 'before' => '' );

--- a/bbpress/form-reply.php
+++ b/bbpress/form-reply.php
@@ -127,28 +127,42 @@
 
 						<?php if ( bbp_is_subscriptions_active() && ! bbp_is_anonymous() && ( ! bbp_is_reply_edit() || ( bbp_is_reply_edit() && ! bbp_is_reply_anonymous() ) ) ) : ?>
 
-							<?php do_action( 'bbp_theme_before_reply_form_subscription' ); ?>
+							<?php
+							if (
+								! function_exists( 'bb_enabled_legacy_email_preference' ) ||
+								(
+									function_exists( 'bb_enabled_legacy_email_preference' ) &&
+									(
+										bb_enabled_legacy_email_preference() ||
+										( ! bb_enabled_legacy_email_preference() && bb_get_modern_notification_admin_settings_is_enabled( 'bb_forums_subscribed_reply' ) )
+									)
+								)
+							) {
+								?>
 
-							<div class="bb_subscriptions_active">
+								<?php do_action( 'bbp_theme_before_reply_form_subscription' ); ?>
 
-								<input name="bbp_topic_subscription" id="bbp_topic_subscription" class="bs-styled-checkbox" type="checkbox" value="bbp_subscribe"<?php bbp_form_topic_subscribed(); ?> tabindex="<?php bbp_tab_index(); ?>" />
+								<div class="bb_subscriptions_active">
 
-								<?php if ( bbp_is_reply_edit() && ( bbp_get_reply_author_id() !== bbp_get_current_user_id() ) ) : ?>
+									<input name="bbp_topic_subscription" id="bbp_topic_subscription" class="bs-styled-checkbox" type="checkbox" value="bbp_subscribe"<?php bbp_form_topic_subscribed(); ?> tabindex="<?php bbp_tab_index(); ?>" />
 
-									<label for="bbp_topic_subscription"><?php esc_html_e( 'Notify the author of replies via email', 'buddyboss-theme' ); ?></label>
+									<?php if ( bbp_is_reply_edit() && ( bbp_get_reply_author_id() !== bbp_get_current_user_id() ) ) : ?>
 
-								<?php else : ?>
+										<label for="bbp_topic_subscription"><?php esc_html_e( 'Notify the author of replies via email', 'buddyboss-theme' ); ?></label>
 
-									<label for="bbp_topic_subscription"><?php esc_html_e( 'Notify me of replies via email', 'buddyboss-theme' ); ?></label>
+									<?php else : ?>
 
-								<?php endif; ?>
+										<label for="bbp_topic_subscription"><?php esc_html_e( 'Notify me of replies via email', 'buddyboss-theme' ); ?></label>
 
-							</div>
+									<?php endif; ?>
 
-							<?php do_action( 'bbp_theme_after_reply_form_subscription' ); ?>
+								</div>
+
+								<?php do_action( 'bbp_theme_after_reply_form_subscription' ); ?>
+
+						<?php } ?>
 
 						<?php endif; ?>
-
 
 						<?php do_action( 'bbp_theme_before_reply_form_submit_wrapper' ); ?>
 
@@ -204,13 +218,14 @@
 
 <?php else : ?>
 
-	<div id="no-reply-<?php bbp_topic_id(); ?>" class="bbp-no-reply">
-		<div class="bp-feedback info">
-			<span class="bp-icon" aria-hidden="true"></span>
-			<p><?php is_user_logged_in() ? esc_html__( 'You cannot reply to this discussion.', 'buddyboss-theme' ) : esc_html__( 'Log in  to reply.', 'buddyboss-theme' ); ?></p>
+<?php if ( is_user_logged_in() ) : ?>
+		<div id="no-reply-<?php bbp_topic_id(); ?>" class="bbp-no-reply">
+			<div class="bp-feedback info">
+				<span class="bp-icon" aria-hidden="true"></span>
+				<p><?php esc_html_e( 'You cannot reply to this discussion.', 'buddyboss-theme' ); ?></p>
+			</div>
 		</div>
-	</div>
-
+	<?php endif; ?>
 <?php endif; ?>
 
 <?php if ( bbp_is_reply_edit() ) : ?>

--- a/buddypress/activity/widget.php
+++ b/buddypress/activity/widget.php
@@ -16,7 +16,6 @@
 		while ( bp_activities() ) :
 			bp_the_activity();
 		?>
-		<?php if ( bp_activity_has_content() ) : ?>
 		<div class="activity-update">
 
 			<div class="update-item">
@@ -52,8 +51,6 @@
 			</div>
 
 		</div>
-
-		<?php endif; ?>
 
 		<?php endwhile; ?>
 

--- a/buddypress/groups/single/members-loop.php
+++ b/buddypress/groups/single/members-loop.php
@@ -30,14 +30,12 @@ $follow_class = $is_follow_active ? 'follow-active' : '';
 
 	<?php bp_nouveau_group_hook( 'before', 'members_list' ); ?>
 
-	<script> 
-		jQuery(document).foundation();
-	</script>
 
 	<?php
-	$count = groups_get_current_group()->total_member_count;
 	global $bfc_dropdown_prefix;
-
+	$count = groups_get_current_group()->total_member_count;
+	// We use 21 as the break point between groups that feel "small" and those that feel "large". This page always displays
+	// the group members' avatars and names. For small groups, it also displays their self intros.
 	if ($count <22) : ?>
 	<ul id="members-intros" class="bp-list">
 	<?php
@@ -131,6 +129,10 @@ $follow_class = $is_follow_active ? 'follow-active' : '';
 		?>
 
 	</ul>
+
+	<script> 
+		jQuery(document).foundation();
+	</script>
 
 	<?php bp_nouveau_group_hook( 'after', 'members_list' ); ?>
 

--- a/buddypress/groups/single/parts/item-nav.php
+++ b/buddypress/groups/single/parts/item-nav.php
@@ -7,15 +7,11 @@
  */
 ?>
 
-<nav class="<?php bp_nouveau_single_item_nav_classes(); ?>" id="object-nav" role="navigation" aria-label="<?php esc_attr_e( 'Group menu', 'buddyboss' ); ?>"><!-- bfc-marker item-nav.php -->
+<nav class="<?php bp_nouveau_single_item_nav_classes(); ?>" id="object-nav" role="navigation" aria-label="<?php esc_attr_e( 'Group menu', 'buddyboss' ); ?>">
 
 	<?php if ( bp_nouveau_has_nav( array( 'object' => 'groups' ) ) ) : ?>
 
 		<ul>
-
-			<!-- <li class="bfc-group-name-nav">
-			<?php echo esc_attr( bp_get_group_name() ); ?>
-			</li> -->
 
 			<?php
 			while ( bp_nouveau_nav_items() ) :

--- a/functions/bfc-functions.php
+++ b/functions/bfc-functions.php
@@ -324,11 +324,11 @@ function bfc_followers_args ( $qs, $object ) {
 }
 
 function bfc_remove_bp_forum_notifications () {
-	if ('yes' == (bp_get_user_meta(bp_loggedin_user_id(), 'notification_forums_following_reply', true ))) {
-		bp_update_user_meta (bp_loggedin_user_id(), 'notification_forums_following_reply', 'no' );
+	if ('no' == (bp_get_user_meta(bp_loggedin_user_id(), 'notification_forums_following_reply', true ))) {
+		bp_update_user_meta (bp_loggedin_user_id(), 'notification_forums_following_reply', 'yes' );
 	}
-	if ('yes' == (bp_get_user_meta(bp_loggedin_user_id(), 'notification_forums_following_topic', true ))) {
-		bp_update_user_meta (bp_loggedin_user_id(), 'notification_forums_following_topic', 'no' );
+	if ('no' == (bp_get_user_meta(bp_loggedin_user_id(), 'notification_forums_following_topic', true ))) {
+		bp_update_user_meta (bp_loggedin_user_id(), 'notification_forums_following_topic', 'yes' );
 	}
 }
 add_action( 'bp_notification_settings', 'bfc_remove_bp_forum_notifications', 99 );
@@ -339,7 +339,7 @@ function bfc_group_members( $group_id = false, $role = array() ) {
 		return '';
 	}
 
-	$members = new \BP_Group_Member_Query(
+	$members = new BP_Group_Member_Query(
 		array(
 			'group_id'     => $group_id,
 			'per_page'     => 10,
@@ -485,3 +485,4 @@ function bfc_rename_group_navs ($link_text,$nav_item,$displayed_nav){
 
 add_filter( 'bp_nouveau_get_nav_link_text', 'bfc_rename_group_navs',10,3);
 
+?>

--- a/functions/widgets.php
+++ b/functions/widgets.php
@@ -71,13 +71,16 @@ add_action( 'widgets_init', 'bfc_register_messages_widget' );
 
 function register_la_widget() {
     register_widget("bsp_Activity_Widget");
-
 }
-
 add_action('widgets_init', 'register_la_widget');
 
 
-//latest activity widget
+function bfc_register_latest_activities_widget() {
+	register_widget( 'bfc_latest_activities' );
+}
+add_action('widgets_init', 'bfc_register_latest_activities_widget');
+
+//latest activity forum widget
 class bsp_Activity_Widget extends WP_Widget {
 
 	/**
@@ -602,6 +605,230 @@ class bfc_messages_widget extends WP_Widget {
 		return $instance;
 	}
 	 
-	// Class wpb_widget ends here
-	} 
+	
+} // Class bfc_messages_widget ends here
+
+/**
+ * BFC Activity widget based on
+ * BP Nouveau Activity widgets
+ *
+ * @since BuddyPress 3.0.0
+ * @version 3.1.0
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * A widget to display the latest activities of your community!
+ *
+ * @since BuddyPress 3.0.0
+ */
+class bfc_latest_activities extends WP_Widget {
+	/**
+	 * Construct the widget.
+	 *
+	 * @since BuddyPress 3.0.0
+	 */
+	public function __construct() {
+
+		/**
+		 * Filters the widget options for the bfc_latest_activities widget.
+		 *
+		 * @since BuddyPress 3.0.0
+		 *
+		 * @param array $value Array of widget options.
+		 */
+		$widget_ops = apply_filters(
+			'bfc_latest_activities', array(
+				'classname'                   => 'bfc-latest-activities buddypress',
+				'description'                 => __( 'Select to display the latest activity updates, by type, posted within your community.', 'buddyboss' ),
+				'customize_selective_refresh' => true,
+			)
+		);
+
+		parent::__construct( false, __( '(BFC) Latest Activities', 'buddyboss' ), $widget_ops );
+	}
+
+
+	/**
+	 * Display the widget content.
+	 *
+	 * @since BuddyPress 3.0.0
+	 *
+	 * @param array $args     Widget arguments.
+	 * @param array $instance Widget settings, as saved by the user.
+	 */
+	public function widget( $args, $instance ) {
+		// Default values
+		$title      = __( 'Updates', 'buddyboss' );
+		$type       = 'activity_update';
+		$max        = 15;
+		$bp_nouveau = bp_nouveau();
+
+		// Check instance for a custom title
+		if ( ! empty( $instance['title'] ) ) {
+			$title = $instance['title'];
+		}
+
+		/**
+		 * Filters the bfc_latest_activities widget title.
+		 *
+		 * @since BuddyPress 3.0.0
+		 *
+		 * @param string $title    The widget title.
+		 * @param array  $instance The settings for the particular instance of the widget.
+		 * @param string $id_base  Root ID for all widgets of this type.
+		 */
+		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
+
+		// Check instance for custom max number of activities to display
+		if ( ! empty( $instance['max'] ) ) {
+			$max = (int) $instance['max'];
+		}
+
+		// Check instance for custom activity types
+		if ( ! empty( $instance['type'] ) ) {
+			$type    = maybe_unserialize( $instance['type'] );
+			if ( ! is_array( $type ) ) {
+				$type = (array) maybe_unserialize( $type );
+			}
+			$classes = array_map( 'sanitize_html_class', array_merge( $type, array( 'bfc-latest-activities' ) ) );
+
+			// Add classes to the container
+			$args['before_widget'] = str_replace( 'bfc-latest-activities', join( ' ', $classes ), $args['before_widget'] );
+		}
+
+		echo $args['before_widget'];
+
+		if ( $title ) {
+			echo $args['before_title'] . $title . $args['after_title'];
+		}
+
+		$reset_activities_template = null;
+		if ( ! empty( $GLOBALS['activities_template'] ) ) {
+			$reset_activities_template = $GLOBALS['activities_template'];
+		}
+
+		/**
+		 * Globalize the activity widget arguments.
+		 * @see bp_nouveau_activity_widget_query() to override
+		 */
+
+		$followers = bp_get_following( array ('user_id' => bp_loggedin_user_id()) );
+		$followers[] = bp_loggedin_user_id();
+		$followers_and_me = implode(',', (array)$followers); 
+		// var_dump($followers);
+		$bp_nouveau->activity->widget_args = array(
+			'max'          => 10,
+			'scope'        => 'all',
+			'user_id'      => $followers_and_me,
+			'object'       => false,
+			'action'       => 'activity_update', //join( ',', $type ),
+			'primary_id'   =>  0, //bp_get_current_group_id(),
+			'secondary_id' => 0,
+		);
+
+		If (bp_current_component() == 'groups') {
+			$group_members_result = groups_get_group_members( array( 'group_id' => bp_get_group_id(), 'exclude_admins_mods' => false) );
+			$group_members = array();
+
+			foreach(  $group_members_result['members'] as $member ) {
+				$group_members[] = $member->ID;
+			}
+			
+			$bp_nouveau->activity->widget_args = array(
+				'max'          => $max,
+				'scope'        => 'groups',
+				'user_id'      => implode(',', $group_members),
+				'object'       => 'groups',
+				'action'       => 'activity_update,joined_group',//join( ',', $type ),
+				'primary_id'   => bp_get_current_group_id(),
+				'secondary_id' => 0,
+			);
+		}
+
+		bp_get_template_part( 'activity/widget' );
+
+		// Reset the globals
+		$GLOBALS['activities_template']    = $reset_activities_template;
+		$bp_nouveau->activity->widget_args = array();
+
+		echo $args['after_widget'];
+	}
+
+	/**
+	 * Update the widget settings.
+	 *
+	 * @since BuddyPress 3.0.0
+	 *
+	 * @param array $new_instance The new instance settings.
+	 * @param array $old_instance The old instance settings.
+	 *
+	 * @return array The widget settings.
+	 */
+	public function update( $new_instance, $old_instance ) {
+		$instance = $old_instance;
+
+		$instance['title'] = strip_tags( $new_instance['title'] );
+		$instance['max']   = 5;
+		if ( ! empty( $new_instance['max'] ) ) {
+			$instance['max'] = $new_instance['max'];
+		}
+
+		$instance['type'] = maybe_serialize( array( 'activity_update' ) );
+		if ( ! empty( $new_instance['type'] ) ) {
+			$instance['type'] = maybe_serialize( $new_instance['type'] );
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Display the form to set the widget settings.
+	 *
+	 * @since BuddyPress 3.0.0
+	 *
+	 * @param array $instance Settings for this widget.
+	 *
+	 * @return string HTML output.
+	 */
+	public function form( $instance ) {
+		$instance = wp_parse_args( (array) $instance, array(
+			'title' => __( 'Updates', 'buddyboss' ),
+			'max'   => 5,
+			'type'  => '',
+		) );
+
+		$title = esc_attr( $instance['title'] );
+		$max   = (int) $instance['max'];
+
+		$type = array( 'activity_update' );
+		if ( ! empty( $instance['type'] ) ) {
+			$type = maybe_unserialize( $instance['type'] );
+			if ( ! is_array( $type ) ) {
+				$type = (array) maybe_unserialize( $type );
+			}
+		}
+		?>
+		<p>
+			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php esc_html_e( 'Title:', 'buddyboss' ); ?></label>
+			<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>" />
+		</p>
+
+		<p>
+			<label for="<?php echo $this->get_field_id( 'max' ); ?>"><?php _e( 'Maximum amount to display:', 'buddyboss' ); ?></label>
+			<input type="number" class="widefat" id="<?php echo $this->get_field_id( 'max' ); ?>" name="<?php echo $this->get_field_name( 'max' ); ?>" value="<?php echo intval( $max ); ?>" step="1" min="1" max="20" />
+		</p>
+		<p>
+			<label for="<?php echo $this->get_field_id( 'type' ); ?>"><?php esc_html_e( 'Activity Type:', 'buddyboss' ); ?></label>
+			<select class="widefat" multiple="multiple" id="<?php echo $this->get_field_id( 'type' ); ?>" name="<?php echo $this->get_field_name( 'type' ); ?>[]">
+				<?php foreach ( bp_nouveau_get_activity_filters() as $key => $name ) : ?>
+					<option value="<?php echo esc_attr( $key ); ?>" <?php selected( in_array( $key, $type, true ) ); ?>><?php echo esc_html( $name ); ?></option>
+				<?php endforeach; ?>
+			</select>
+		</p>
+		<?php
+	}
+} // Class bfc_latest_activities ends here
 


### PR DESCRIPTION
I've begun a new cycle of programming. This PR mostly adds a new widget to display activity updates on the user and group dashboards. It also brings our files up-to-date with BB Theme 1.8.9.1.

There's more to be done on refining the UI for the widget but the basic functionality is now in place. On the user dashboard, it displays update messages from people you are following. On the group dashboard, it displays group-related update messages plus new members joins.