### PR TITLE
Exclude forum posts by logged-in user in widget + date formatting

### DIFF
--- a/bbpress/loop-topic-list.php
+++ b/bbpress/loop-topic-list.php
@@ -81,9 +81,10 @@
 
 						<?php if( $topic_post_count > 1 ) : ?>
 							<span class="bs-replied">
+								<span class="bs-separator">&middot;</span>
 								<span class="bbp-topic-freshness-author">
 								<?php
-								echo  ' - Latest reply by';
+								echo  'Latest reply by ';
 								bbp_author_link( array( 'post_id' => bbp_get_topic_last_active_id(), 'type'    => 'name', ) );
 								?>
 								</span> 

--- a/functions/widgets.php
+++ b/functions/widgets.php
@@ -315,6 +315,7 @@ class bsp_Activity_Widget extends WP_Widget {
 							// $output = bbp_get_topic_last_active_time( $topic_id ) ; 
 							$last_active = get_post_field( 'post_date_gmt', $post_id );
 							$output = bfc_nice_date( strtotime( $last_active ) );
+							echo '<span class="bs-separator">&middot;&nbsp;</span>';
 							echo '<span class="bsp-activity-freshness bsp-la-freshness">'.$output. '</span>';
 							endif; 
 							?>
@@ -545,12 +546,16 @@ function bfc_activity_info(){
 	// } elseif (str_contains($author, 'in <a href="')) {
 	// 	$author .= ' ';
 	}
-	$author .= ' ';
+
 	if(str_contains($author, '<br>')) {
 		$author .= ' ';
 	}else {
 		$author .= '<br>';
 	}
+
+	if(str_contains($author, '<br> in ')) {
+		$author .= '<span class="bs-separator">&middot;&nbsp;</span>';
+	} 
 	// Get the time since this activity was recorded.
 	$date_recorded = strtotime( $activities_template->activity->date_recorded );
 

--- a/functions/widgets.php
+++ b/functions/widgets.php
@@ -213,7 +213,8 @@ class bsp_Activity_Widget extends WP_Widget {
 		
 		// The default forum query with allowed forum ids array added
 		//reset the max to be shown
-		$topics_query['posts_per_page'] =(int) $settings['max_shown'] ;
+		$shown_topics = (int) $settings['max_shown'] ;
+		$topics_query['posts_per_page'] = 3*$shown_topics;
 		
 		//add any include/exclude forums ;
 		if (!empty ($settings['post_parent__not_in'])) $topics_query['post_parent__not_in'] = $settings['post_parent__not_in'] ;
@@ -245,7 +246,8 @@ class bsp_Activity_Widget extends WP_Widget {
 		
 		$helptip = "<div class='bfc-helptip'><span class= 'bb-icon-help-circle' ></span><span class='bfc-helptiptext'>";
 		If (bp_current_component() == 'groups') {
-			$helptip .= "<p>These are the <strong>most recent forum posts</strong> from this group.</p>
+			$helptip .= "<p>These are the <strong>most recent forum posts by others</strong> from this group.</p>
+			<p>Threads where your post is the most recent aren't included since you've seen them.</p>
 			<p>To see the full post in its thread, click the <span class = 'bfc-widget-actions bb-icon-arrow-up-right'></span> symbol to the right of the sender's name.</p>			
 			<p>Once you've gone to the full post, you can also <em>like</em> it and/or add a reply.</p>			
 			<p>Clicking on the thread subject takes you to the start of the thread.</p>			
@@ -253,7 +255,8 @@ class bsp_Activity_Widget extends WP_Widget {
 			<p>Hover over the sender's picture for quick access to sending them a new message, following them or going to their profile.</p>			
 			<p>Clicking on the sender's name also takes you to their profile.</p>";
 		} else {
-			$helptip .= "<p>These are the <strong>most recent forum posts</strong> from the <strong>groups</strong> you are part of.</p>
+			$helptip .= "<p>These are the <strong>most recent forum posts by others</strong> from the <strong>groups</strong> you are part of.</p>
+			<p>Threads where your post is the most recent aren't included since you've seen them.</p>
 			<p>To see the full post in its thread, click the <span class = 'bfc-widget-actions bb-icon-arrow-up-right'></span> symbol to the right of the sender's name.</p>
 			<p>Once you've gone to the full post, you can also <em>like</em> it and/or add a reply.</p>			
 			<p>Clicking on the thread subject takes you to the start of the thread.</p>			
@@ -269,7 +272,9 @@ class bsp_Activity_Widget extends WP_Widget {
 		
 		<ul class="bfc-la-ul">
 
-			<?php while ( $widget_query->have_posts() ) :
+			<?php 
+			$visible_topics = 0;
+			while ( $widget_query->have_posts() ) :
 				
 
 				$widget_query->the_post();
@@ -298,7 +303,9 @@ class bsp_Activity_Widget extends WP_Widget {
 				<?php 
 				global $bfc_dropdown_prefix;
 				$type = $bfc_dropdown_prefix . '-forum';
-				$person = bbp_get_reply_author_id($post_id);?>
+				$person = bbp_get_reply_author_id($post_id);
+				if($person == bp_loggedin_user_id()) {continue;}
+				?>
 
 				<li class="bfc-la-li" data-bp-item-id="<?php echo $author_id; ?>" data-bp-item-component="members">
 				<div class = "update-item">
@@ -348,7 +355,10 @@ class bsp_Activity_Widget extends WP_Widget {
 					</div>
 				</li>
 
-			<?php endwhile; ?>
+			<?php 
+			$visible_topics++;
+			if ($visible_topics == $shown_topics) {break;}
+			endwhile; ?>
 
 		</ul>
 


### PR DESCRIPTION
I changed my mind and decided to exclude, in the forum-posts widget, the threads where the most recent post is by the logged in user. Presumable, the user has read those threads. That keeps the focus in the widget on posts that are new to the user.