### PR TITLE
"View as", restricting the group timeline and readability tweaks

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -201,7 +201,11 @@ nav#object-nav li.bfc-group-name-nav{
 #buddypress .bb-grid  .dropdown-pane .follow-button, 
 #buddypress .bp-list .dropdown-pane .follow-button, 
 #bfc-user-panels .dropdown-pane .follow-button, 
-#bfc-user-accordion .dropdown-pane .follow-button {
+#bfc-user-accordion .dropdown-pane .follow-button,
+#buddypress .bb-grid  .dropdown-pane .switch-button, 
+#buddypress .bp-list .dropdown-pane .switch-button, 
+#bfc-user-panels .dropdown-pane .switch-button, 
+#bfc-user-accordion .dropdown-pane .switch-button {
 	background: transparent;
 	border: 0;
 	border-radius: 0;
@@ -223,6 +227,8 @@ nav#object-nav li.bfc-group-name-nav{
 	text-align: center;
 	width: 150px;
 	padding: 10px;
+	color: #007CFF;
+	line-height: 1.2;
 }
 
 .bfc-dropdown-span {
@@ -282,11 +288,15 @@ nav#object-nav li.bfc-group-name-nav{
 #members-dir-grid.members #members-list div.list-wrap {
 	display: flex;
 	border-radius: 0px;
-	background: #fafafa;
+	background: #fff;
 	border: 0;
 	padding : 0;
 	min-height: 40px;
 	}
+
+#buddypress .members-directory-content {
+	background-color: #fff;
+}
 
 @media (max-width:767px) {
 	#members-group-list.group_members ul#members-list,
@@ -961,6 +971,27 @@ nav#object-nav li.bfc-group-name-nav{
 
 .flex-video.widescreen, .responsive-embed.widescreen {
 	padding-bottom: 75%;
+}
+
+#buddypress nav#object-nav a,
+#header-aside a.user-link,
+#site-navigation .primary-menu a {
+	font-size: 15px;
+}
+
+.bp-profile-search-widget .submit-wrapper input {
+	min-width: 0;
+}
+
+#buddypress .bp-navs ul li.selected a, 
+nav#object-nav .selected > a {
+	color: hsl(211deg 100% 50%) !important;
+}
+
+.primary-menu .current_page_item > a {
+	height: 62px;
+	border-bottom-style: solid;
+    border-bottom-width: 1px;
 }
 
 /* Events Calendar */

--- a/buddypress/groups/single/parts/item-nav.php
+++ b/buddypress/groups/single/parts/item-nav.php
@@ -16,6 +16,9 @@
 			<?php
 			while ( bp_nouveau_nav_items() ) :
 				bp_nouveau_nav_item();
+				if (bp_nouveau_get_nav_link_text() == 'Timeline' && !(is_super_admin( bp_loggedin_user_id()) || bp_is_item_admin()) ) {
+					continue;
+				}
 			?>
 
 				<li id="<?php bp_nouveau_nav_id(); ?>" class="<?php bp_nouveau_nav_classes(); ?>">

--- a/functions/bfc-functions.php
+++ b/functions/bfc-functions.php
@@ -20,12 +20,18 @@ function my_myme_types( $mime_types ) {
 
 function bfc_member_dropdown( $type, $instance_id, $person, $follow_class ) {
 	$user = bp_loggedin_user_id();
+	$old_user = bp_current_member_switched();
 	$output = '<div class="dropdown-pane ' . $follow_class . '" id="' . $type . '-dropdown-' . esc_attr( $instance_id ) . '" data-dropdown data-hover="true" data-hover-pane="true" data-auto-focus="false">';
 	if ( $person != $user ) {
 		$output .= '<a href="/members/' . bp_core_get_username( $user ) . '/messages/compose/?r=' . bp_core_get_username( $person ) . '">Send a message</a><br>';
 		if ( 'follow-active' == $follow_class ) {
 			$output .= bp_get_add_follow_button( $person, $user );
 		}
+		if ( is_super_admin( $user ) ) {
+			$output .= bp_get_add_switch_button( $person);
+		}
+	} elseif ( $old_user ) {
+		$output .= bp_get_add_switch_button( $old_user->ID );
 	}
 	$output .= '<a href="/members/' . bp_core_get_username( $person ) . '">Visit profile</a></div>';
 	return $output;


### PR DESCRIPTION
This includes a convenience function for site admins that adds the link to "view as" to the avatar dropdown but only visible by site admins.