### PR TITLE
Fix visibility levels for timeline updates

### DIFF
--- a/buddypress/common/js-templates/activity/parts/bp-activity-post-case-privacy.php
+++ b/buddypress/common/js-templates/activity/parts/bp-activity-post-case-privacy.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * The template for displaying activity post case privacy
+ *
+ * This template can be overridden by copying it to yourtheme/buddypress/common/js-templates/activity/parts/bp-activity-post-case-privacy.php.
+ *
+ * @since   BuddyBoss 1.8.6
+ * @version 1.8.6
+ */
+
+?>
+<script type="text/html" id="tmpl-activity-post-case-privacy">
+	
+	<?php 
+		$visibility_levels = bp_activity_get_visibility_levels();
+		if (!isset ($visibility_levels['public'])) : ?>
+			<# if ( 'public' == data.privacy ) {  data.privacy = 'loggedin';  } #>
+			<?php if (bp_loggedin_user_id() == bp_displayed_user_id()) : ?>
+			<div id="bp-activity-privacy-point" class="{{data.privacy}}" data-bp-tooltip-pos="up" data-bp-tooltip="<?php esc_html_e( 'Set by album privacy', 'bfcommons-theme' ); ?>">
+				<span class="privacy-point-icon"></span>
+				<span class="bp-activity-privacy-status">
+					<# if ( data.privacy === 'loggedin' ) { #>
+						<?php esc_html_e( 'Anyone In The Network', 'bfcommons-theme' ); ?>
+					<# } else if ( data.privacy === 'friends' ) { #>
+						<?php esc_html_e( 'My Connections', 'bfcommons-theme' ); ?>
+					<# } else if ( data.privacy === 'onlyme' ) { #>
+						<?php esc_html_e( 'Only Me', 'bfcommons-theme' ); ?>
+					<# } else { #>
+						<?php esc_html_e( 'Group', 'bfcommons-theme' ); ?>
+					<# } #>
+				</span>
+				<i class="bb-icon-chevron-down"></i>
+			</div>
+			<?php endif; 
+		else: ?>
+			<div id="bp-activity-privacy-point" class="{{data.privacy}}" data-bp-tooltip-pos="up" data-bp-tooltip="<?php esc_html_e( 'Set by album privacy', 'bfcommons-theme' ); ?>">
+				<span class="privacy-point-icon"></span>
+				<span class="bp-activity-privacy-status">
+					<# if ( data.privacy === 'public' ) {  #>
+						<?php esc_html_e( 'Public', 'bfcommons-theme' ); ?>
+					<# } else if ( data.privacy === 'loggedin' ) { #>
+						<?php esc_html_e( 'Anyone In The Network', 'bfcommons-theme' ); ?>
+					<# } else if ( data.privacy === 'friends' ) { #>
+						<?php esc_html_e( 'My Connections', 'bfcommons-theme' ); ?>
+					<# } else if ( data.privacy === 'onlyme' ) { #>
+						<?php esc_html_e( 'Only Me', 'bfcommons-theme' ); ?>
+					<# } else { #>
+						<?php esc_html_e( 'Group', 'bfcommons-theme' ); ?>
+					<# } #>
+				</span>
+				<i class="bb-icon-chevron-down"></i>
+			</div>
+		<?php endif;
+	?>
+</script>

--- a/buddypress/common/js-templates/activity/parts/bp-activity-post-form-privacy.php
+++ b/buddypress/common/js-templates/activity/parts/bp-activity-post-form-privacy.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * The template for displaying activity post form privacy
+ *
+ * This template can be overridden by copying it to yourtheme/buddypress/common/js-templates/activity/parts/bp-activity-post-form-privacy.php.
+ *
+ * @since   BuddyBoss 1.8.6
+ * @version 1.8.6
+ */
+
+?>
+<script type="text/html" id="tmpl-activity-post-form-privacy">
+	<div class="bp-activity-privacy__list">
+		<?php foreach ( bp_activity_get_visibility_levels() as $key => $privacy ) : ?>
+
+			<label for="<?php echo esc_attr( $key ); ?>" class="bb-radio-style bp-activity-privacy__label bp-activity-privacy__label-<?php echo esc_attr( $key ); ?>">
+				<div class="privacy-tag-wrapper">
+					<span class="privacy-figure privacy-figure--<?php echo esc_attr( $key ); ?>"></span>
+					<div class="privacy-tag">
+						<div class="privacy-label"><?php echo esc_html( $privacy ); ?></div>
+						<span class="privacy-sub-label">
+							<?php
+							if ( 'public' === $key ) {
+								esc_html_e( 'Visible to anyone, on or off this site', 'bfcommons-theme' );
+							} elseif ( 'loggedin' === $key ) {
+								esc_html_e( 'Visible to all members on this site', 'bfcommons-theme' );
+							} elseif ( 'friends' === $key ) {
+								esc_html_e( 'Visible only to your connections', 'bfcommons-theme' );
+							} elseif ( 'onlyme' === $key ) {
+								esc_html_e( 'Visible only to you', 'bfcommons-theme' );
+							}
+							?>
+						</span>
+					</div>
+				</div>
+				<span class="privacy-radio">
+					<input type="radio" id="<?php echo esc_attr( $key ); ?>" class="bp-activity-privacy__input" name="privacy" value="<?php echo esc_attr( $key ); ?>" data-title="<?php echo esc_attr( $privacy ); ?>" <?php checked( ( 'loggedin' === $key ) ); ?>>
+					<span></span>
+				</span>
+			</label>
+		<?php endforeach; ?>
+
+		<?php
+		if ( bp_is_active( 'groups' ) ) {
+			if ( 0 !== (int) groups_total_groups_for_user( bp_loggedin_user_id() ) ) {
+				?>
+				<label for="group" class="bb-radio-style bp-activity-privacy__label bp-activity-privacy__label-group">
+					<div class="privacy-tag-wrapper">
+						<span class="privacy-figure privacy-figure--group"></span>
+						<div class="privacy-tag">
+							<div class="privacy-label"><?php esc_html_e( 'Post in Group', 'bfcommons-theme' ); ?><i class="bb-icon-chevron-right"></i></div>
+							<span class="privacy-sub-label"><?php esc_html_e( 'Visible to members of a group', 'bfcommons-theme' ); ?></span>
+						</div>
+					</div>
+					<span class="privacy-radio"><input type="radio" id="group" class="bp-activity-privacy__input" name="privacy" value="group" data-title="<?php esc_html_e( 'Group', 'bfcommons-theme' ); ?>"><span></span></span>
+				</label>
+				<?php
+			}
+		}
+		?>
+	</div>
+</script>

--- a/functions/bfc-functions.php
+++ b/functions/bfc-functions.php
@@ -571,4 +571,19 @@ function bfc_members_per_page( $retval ) {
     return $retval;
 }
 add_filter( 'bp_after_has_members_parse_args', 'bfc_members_per_page' );
+
+add_filter('bp_activity_get_visibility_levels', 'bfc_activity_visibility_levels'); 
+
+function bfc_activity_visibility_levels($allowed_visibilities){
+	unset( $allowed_visibilities['public'] );
+	return $allowed_visibilities;
+}
+
+add_filter( 'bp_before_activity_add_parse_args', 'bfc_custom_change_privacy_when_public', 100 );
+
+function bfc_custom_change_privacy_when_public( $r ) {  
+if ( 'public' === $r['privacy'] ) {    $r['privacy'] = 'loggedin';  }  
+return $r;
+}
+
 ?>


### PR DESCRIPTION
Remove the “public” level and remove “onlyme” when posting on someone else’s timeline.