### PR TITLE
Catching up on fixes and prepping for new site

### DIFF
--- a/docs/docs-header.php
+++ b/docs/docs-header.php
@@ -1,7 +1,7 @@
 <?php do_action( 'bp_docs_before_doc_header' ) ?>
 <!-- header start-->
 <!-- <?php /* Subnavigation on user pages is handled by BP's core functions */ ?> -->
-<?php if ( ! (bp_is_user() || bp_docs_is_single_doc()) && current_user_can( 'bp_docs_create' )): ?>
+<?php if ( ! (bp_is_user() || bp_docs_is_single_doc()) && current_user_can( 'delete_others_posts' )): // was 'bp_docs_create'; this restricts to site editor or admin ?> 
 	<div class="item-list-tabs no-ajax" id="subnav" role="navigation">
 		<?php bp_docs_create_button(); ?>
 	 </div> <!-- .item-list-tabs -->

--- a/docs/docs-loop.php
+++ b/docs/docs-loop.php
@@ -9,7 +9,7 @@ if ( ! $bp_docs_do_theme_compat ) : ?>
 <!-- docs-loop start -->
 <div class="<?php bp_docs_container_class(); ?> bp-docs-directory">
 
-<?php if ('bfcom-help' == urldecode( $_GET['bpd_tag'] )) : ?>
+<?php if ('bfcom-help' == urldecode( isset($_GET['bpd_tag'] ) ? $_GET['bpd_tag'] : '') ) : ?>
 
 	<h1 class="directory-title">
 		<?php echo 'Commons Help'; ?>


### PR DESCRIPTION
- Restricting site-wide doc creation to editor and admin roles
- Checking that GET['bpd_tag'] is set
- Restricting the Quick Contact dropdown to users with profiles (i.e. not deleted or anonymous users)
- Excluding purely admin users from People list
- Restricting tinyMCE editor to only the intro text area in the profile.