### PR TITLE
More fixes and prepping for the new site

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -531,11 +531,11 @@ code {
 	margin-right: 15px;
 }
 
-.bp-docs .media-router .media-menu-item {
+.media-router .media-menu-item {
 	color: #007CFF;
 }
 
-.bp-docs .media-router .media-menu-item.active {
+.media-router .media-menu-item.active {
 	color: #1d2327;
 }
 

--- a/buddypress/groups/single/parts/item-nav.php
+++ b/buddypress/groups/single/parts/item-nav.php
@@ -18,6 +18,8 @@
 				bp_nouveau_nav_item();
 				if (bp_nouveau_get_nav_link_text() == 'Timeline' && !(is_super_admin( bp_loggedin_user_id()) || bp_is_item_admin()) ) {
 					continue;
+				} elseif (bp_nouveau_get_nav_link_text() == 'Images') {
+					continue;
 				}
 			?>
 

--- a/buddypress/members/single/member-header.php
+++ b/buddypress/members/single/member-header.php
@@ -39,44 +39,25 @@ remove_filter( 'bp_get_add_follow_button', 'buddyboss_theme_bp_get_add_follow_bu
 
 						<?php bp_nouveau_member_hook( 'before', 'header_meta' ); ?>
 
-						<?php if ( ( bp_is_active( 'activity' ) && bp_activity_do_mentions() ) || bp_nouveau_member_has_meta() ) : ?>
+						<?php if ( ( bp_is_active( 'activity' ) && bp_activity_do_mentions() ) || bfc_member_has_meta() ) : ?>
 							<div class="item-meta">
 								<?php if ( bp_is_active( 'activity' ) && bp_activity_do_mentions() ) : ?>
 									<span class="mention-name">@<?php bp_displayed_user_mentionname(); ?></span>
 								<?php endif; ?>
 
-								<?php if ( bp_is_active( 'activity' ) && bp_activity_do_mentions() && bp_nouveau_member_has_meta() ) : ?>
+								<?php if ( bp_is_active( 'activity' ) && bp_activity_do_mentions() && bfc_member_has_meta() ) : ?>
 									<span class="separator">&bull;</span>
 								<?php endif; ?>
 
 								<?php bp_nouveau_member_hook( 'before', 'header_meta' ); ?>
 
-								<?php if ( bp_nouveau_member_has_meta() ) : ?>
-									<?php bp_nouveau_member_meta(); ?>
+								<?php if ( bfc_member_has_meta() ) : ?>
+									<?php echo bfc_get_member_meta(); ?>
 								<?php endif; ?>
 							</div>	
 						<?php endif; ?>
 
-						<?php if( function_exists( 'bp_is_activity_follow_active' ) && bp_is_active('activity') && bp_is_activity_follow_active() ) { ?>
-							<div class="flex align-items-top member-social">
-                                <!-- <div class="flex align-items-center">
-								    <?php buddyboss_theme_followers_count(); ?>
-								    <?php buddyboss_theme_following_count(); ?>
-                                </div> -->
-								<?php
-		                        if( function_exists('bp_get_user_social_networks_urls') ) {
-			                        echo bp_get_user_social_networks_urls();
-		                        } ?>
-							</div>
-						<?php } else { ?>
-                            <div class="flex align-items-center">
-	                            <?php
-		                        if( function_exists('bp_get_user_social_networks_urls') ) {
-			                        echo bp_get_user_social_networks_urls();
-		                        }
-		                        ?>
-                            </div>
-                        <?php } ?>
+
 					</div>
 
 					<?php remove_filter( 'bp_get_add_friend_button', 'buddyboss_theme_bp_get_add_friend_button' ); ?>

--- a/docs/docs-header.php
+++ b/docs/docs-header.php
@@ -1,7 +1,7 @@
 <?php do_action( 'bp_docs_before_doc_header' ) ?>
 <!-- header start-->
 <!-- <?php /* Subnavigation on user pages is handled by BP's core functions */ ?> -->
-<?php if ( ! (bp_is_user() || bp_docs_is_single_doc()) && current_user_can( 'delete_others_posts' )): // was 'bp_docs_create'; this restricts to site editor or admin ?> 
+<?php if ( bfc_docs_current_user_can_create_in_context(false)): ?> 
 	<div class="item-list-tabs no-ajax" id="subnav" role="navigation">
 		<?php bp_docs_create_button(); ?>
 	 </div> <!-- .item-list-tabs -->

--- a/functions/bfc-docs.php
+++ b/functions/bfc-docs.php
@@ -783,4 +783,28 @@ function bfc_docs_get_the_content($post_id) {
 
 	return $content;
 }
+
+add_filter('bp_docs_current_user_can_create_in_context', 'bfc_docs_current_user_can_create_in_context');
+
+function bfc_docs_current_user_can_create_in_context($can_create) {
+
+	if ( function_exists( 'bp_is_group' ) && bp_is_group() ) {
+		$can_create = current_user_can( 'bp_docs_associate_with_group', bp_get_current_group_id() );
+	} elseif (bp_is_my_profile() || !bp_is_user()) {
+		$can_create = current_user_can( 'delete_others_posts' );
+	} else {
+		$can_create = false;
+	}
+
+	return $can_create;
+}
+
+add_filter('bp_docs_create_button', 'bfc_docs_create_button');
+
+function bfc_docs_create_button ($create_button) {
+	$can_create = bfc_docs_current_user_can_create_in_context('false');
+	if (!$can_create) {$create_button = '';}
+	return $create_button;
+}
+
 ?>

--- a/functions/bfc-docs.php
+++ b/functions/bfc-docs.php
@@ -7,7 +7,7 @@ function bp_docs_is_parent( $classes, $item) {
 	$item_title = $item->title;
 	$is_user_page = bp_is_user();
 	$cur_comp = bp_current_component();
-	if (bp_docs_is_bp_docs_page() && $item->title == 'Docs' && !bp_is_user() && bp_current_component() != 'groups' && !(bfc_doc_has_tag ('bfcom-help') || 'bfcom-help' == urldecode( $_GET['bpd_tag'] ))) {
+	if (bp_docs_is_bp_docs_page() && $item->title == 'Docs' && !bp_is_user() && bp_current_component() != 'groups' && !(bfc_doc_has_tag ('bfcom-help') || 'bfcom-help' == urldecode( isset($_GET['bpd_tag'] ) ? $_GET['bpd_tag'] : ''))) {
 		$classes[] = 'current_page_parent';
 	}
 	return $classes;
@@ -16,7 +16,7 @@ function bp_docs_is_parent( $classes, $item) {
 add_filter('nav_menu_css_class', 'bp_docs_help_is_parent', 10 , 2);
 
 function bp_docs_help_is_parent( $classes, $item) {
-	if (bp_docs_is_bp_docs_page() && $item->title == 'Help' && bp_current_component() != 'groups' && (bfc_doc_has_tag ('bfcom-help') || 'bfcom-help' == urldecode( $_GET['bpd_tag'] ))) {
+	if (bp_docs_is_bp_docs_page() && $item->title == 'Help' && bp_current_component() != 'groups' && (bfc_doc_has_tag ('bfcom-help') || 'bfcom-help' == urldecode( isset($_GET['bpd_tag'] ) ? $_GET['bpd_tag'] : ''))) {
 		$classes[] = 'current_page_parent';
 	}
 	return $classes;
@@ -241,7 +241,7 @@ function bfc_docs_add_single_doc_class ($classes) {
 add_filter('bp_docs_tax_query','bfc_remove_help_docs');
 
 function bfc_remove_help_docs ($query) {
-	if (bp_docs_is_global_directory() && 'bfcom-help' != urldecode( $_GET['bpd_tag'] )) {
+	if (bp_docs_is_global_directory() && 'bfcom-help' != urldecode( isset($_GET['bpd_tag'] ) ? $_GET['bpd_tag'] : '')) {
 		$query[] = array ('taxonomy' => 'bp_docs_tag', 'field'    => 'slug', 'terms'    => 'bfcom-help', 'operator' => 'NOT IN');
 	}
 	return $query;

--- a/functions/bfc-functions.php
+++ b/functions/bfc-functions.php
@@ -138,11 +138,16 @@ function custom_group_tab_title() {
  * Display content of custom tab.
  */
 function custom_group_tab_content() {
+	$group_name = esc_html( bp_get_group_name() );
+	$start_welcome = "Welcome to the ";
+	$end_welcome = "'s dashboard";
+	if(substr($group_name, 0, 3) == 'The') { $start_welcome = "Welcome to "; }
+	if(substr($group_name, -1) == 's') { $end_welcome = "' dashboard"; }
 ?>
 	<div class="group-home-page">
 		<h2 class="user-home-welcome">
-			<span class="user-home-welcome-welcome">Welcome to the </span>
-			<span class="user-home-welcome-name"><?php echo esc_html( bp_get_group_name() ); ?>'s dashboard</span>
+			<span class="user-home-welcome-welcome"><?php echo $start_welcome; ?></span>
+			<span class="user-home-welcome-name"><?php echo esc_html( bp_get_group_name() . $end_welcome ); ?></span>
 		</h2>
 
 		<div class="bfc-group-description"><?php bp_current_group_description();?></div>
@@ -917,14 +922,16 @@ function bfc_exclude_users( $args ) {
     }
  
     // Change it with the actual numeric user ids.
-    $user_ids = array( 1, 3 ); // user ids to exclude.
- 
-    $excluded = array_merge( $excluded, $user_ids );
- 
+	if (bp_core_get_username(2)) {
+		$user_ids = array( 1, 3 ); // user ids to exclude.
+		$excluded = array_merge( $excluded, $user_ids );
+	}
+    
     $args['exclude'] = $excluded;
  
     return $args;
 }
+add_filter( 'bp_after_has_members_parse_args', 'bfc_exclude_users' );
  
 add_filter( 'bp_xprofile_is_richtext_enabled_for_field', 'bfc_disable_rt_function', 10, 2 );
 function bfc_disable_rt_function( $enabled, $field_id ) {
@@ -932,6 +939,17 @@ function bfc_disable_rt_function( $enabled, $field_id ) {
     $enabled = false;
   }
   return $enabled;
+}
+
+function bfc_member_has_meta() {
+	return (bool) bfc_get_member_meta();
+}
+
+function bfc_get_member_meta() {
+	$member = bp_get_displayed_user();
+	$meta = rtrim(xprofile_get_field_data( 22, $member->id ),'c');
+
+	return $meta;
 }
 
 ?>


### PR DESCRIPTION
- Sorting out who can create docs and where
- in Add Media, make inactive tab visible
- remove ‘Images’ from group submenu for now
- put BFNow cohort rather than “date joined” in Profile header
- better checking that variables exist
- excluding admin-only users from People listing
- tweaking the group dashboard to handle groups that start with “The” or end with “s”