### PR TITLE
Removing the return-count limit in get_posts

### DIFF
--- a/functions/bfc-docs.php
+++ b/functions/bfc-docs.php
@@ -933,6 +933,7 @@ function bfc_docs_update_folder_access( $folder_id ) {
 		$fldr_id = $fldr->post_parent;
 		while($fldr_id) {
 			$folder_children = get_posts( array(
+				'numberposts' => -1,
 				'post_type' => 'bp_docs_folder',
 				'post_parent' => $fldr_id,
 				));


### PR DESCRIPTION
This fixes a nasty gotcha. The default return-count limit in get_posts is 5, which is deadly for any folder with more than 5 subfolders – as I have with 8 Week folders in the BFNow Content folder. It wasn't apparent in my local test site, which had only 4 subfolders. I was able to find it by importing the Commons DB into a local version of the site where I could do step debugging.