### PR TITLE
Multiple fixes - see commits - main one is urls for docs in forum posts

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1671,7 +1671,7 @@ body #buddypress .bp-list .action .generic-button .membership-requested:hover {
 	margin-top: -9px;
 }
 
-.like-state > .like-state-likes > span {
+.like-state span.like-state-likes {
 	color: rgb(85,85,85);
 	font-family: "SF UI Text", sans-serif;
 	font-size: 14px;

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -2385,3 +2385,7 @@ body #buddypress .bp-list .action .generic-button .membership-requested:hover {
 .search_results .item-title a {
     color: var(--bb-primary-color);
 }
+
+.bp-single-message-wrap .bp-avatar-wrap img.avatar {
+	width: 40px;
+}

--- a/functions/bfc-editor.php
+++ b/functions/bfc-editor.php
@@ -123,4 +123,15 @@ function bfc_extra_allowed_html_tags(){
 		unset($allowedtags[$dtag]);
 	}
 }
+
+// Fixes a conflict between the bp_doc system and the BuddyBoss document system.
+// Also makes the urls readable outside of the group.
+
+add_filter( 'bbp_get_reply_content', 'bfc_fix_doc_url', 9999);
+add_filter( 'bbp_get_topic_content', 'bfc_fix_doc_url', 9999);
+
+function bfc_fix_doc_url( $content ){
+	$new_content = preg_replace('#href="https:.+?/docs/#', 'href="/docs/', $content);
+	return $new_content;
+}
 ?>

--- a/functions/like-functions.php
+++ b/functions/like-functions.php
@@ -4,7 +4,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Output the state buttons inside an forum post Loop.
+ * Output the state buttons inside a forum post Loop.
  *
  * @since BuddyPress 3.0.0
  */
@@ -16,11 +16,11 @@ function bfc_like_state($post_id) { // from bp_nouveau_activity_state() /buddybo
 	
 	?>
 	<div class="like-state <?php echo $like_users_string ? 'has-likes' : ''; ?>">
-		<a href="javascript:void(0);" class="like-state-likes">
-			<span class="like-text hint--bottom hint--medium hint--multiline" style="<?php echo $like_users_string ? 'display:inline-block' : 'display:none'; ?>" data-hint="<?php echo ( $favorited_users ) ? $favorited_users : ''; ?>" data-post_id="<?php echo $post_id; ?>">
+		<?php echo $favorited_users ? '<a href="javascript:void(0);">': ''; ?>
+			<span class="like-text<?php echo $favorited_users ?' hint--bottom hint--medium hint--multiline':''; ?> like-state-likes" style="<?php echo $like_users_string ? 'display:inline-block' : 'display:none'; ?>"<?php echo ( $favorited_users ) ? ' data-hint="'.$favorited_users : ''; ?>" data-post_id="<?php echo $post_id; ?>">
 				<?php echo $like_users_string ?: ''; ?>
 			</span>
-		</a>
+		<?php echo $favorited_users ? '</a>': ''; ?>
 	</div>
 	<?php
 }
@@ -29,7 +29,6 @@ function bfc_widget_like_state($post_id) {
 	
 	$like_users_string       = bfc_like_users_string( $post_id );
 	$favorited_users = bfc_like_users_tooltip_string( $post_id );
-	// if ($like_users_string == '') { return '';}
 	
 	?>
 	<div class="like-state <?php echo $like_users_string ? 'has-likes' : ''; ?>">
@@ -52,10 +51,6 @@ function bfc_widget_like_state($post_id) {
  * @return int|string
  */
 function bfc_like_users_string( $post_id ) { // bp_activity_get_favorite_users_string from buddyboss-platform/bp-activity/bp-activity-functions.php line 1103
-
-	// if ( ! bp_is_activity_like_active() ) {
-	// 	return 0;
-	// }
 
 	$like_count      = get_post_meta($post_id, 'like_count', true );
 	$like_count      = ( isset( $like_count ) && ! empty( $like_count ) ) ? $like_count : 0;
@@ -116,7 +111,6 @@ function bfc_like_users_string( $post_id ) { // bp_activity_get_favorite_users_s
 			$user_display_name = ! empty( $user_data ) ? bp_core_get_user_displayname( $user_data->ID ) : __( 'Unknown', 'bfcommons-theme' );
 			$return_str       .= $user_display_name . ' ' . __( 'like this.', 'bfcommons-theme' ) . ' ';
 
-			// $return_str .= ' ' . __( '1 other like this', 'bfcommons-theme' );
 		} else {
 
 			$user_data         = get_userdata( array_pop( $favorited_users ) );
@@ -131,7 +125,6 @@ function bfc_like_users_string( $post_id ) { // bp_activity_get_favorite_users_s
 			$user_display_name = ! empty( $user_data ) ? bp_core_get_user_displayname( $user_data->ID ) : __( 'Unknown', 'bfcommons-theme' );
 			$return_str       .= $user_display_name . ' ' . __( 'like this.', 'bfcommons-theme' ) . ' ';
 
-			// $return_str .= ' ' . __( '1 other like this', 'bfcommons-theme' );
 		}
 	} elseif ( 3 < $like_count ) {
 
@@ -184,10 +177,6 @@ function bfc_like_users_string( $post_id ) { // bp_activity_get_favorite_users_s
  * @return string
  */
 function bfc_like_users_tooltip_string( $post_id ) { // from bp_activity_get_favorite_users_tooltip_string buddyboss-platform/bp-activity/bp-activity-functions.php line 1210
-
-	// if ( ! bp_is_activity_like_active() ) {
-	// 	return false;
-	// }
 
 	$current_user_id = get_current_user_id();
 	$favorited_users = get_post_meta($post_id, 'bbp_like_users', true );
@@ -246,22 +235,7 @@ function bfc_ajax_mark_post_like() {
 			'content'    => __( 'Unlike', 'bfcommons-theme' ),
 			'like_users_string' => bfc_like_users_string( $_POST['post_id'] ),
 			'tooltip'    => bfc_like_users_tooltip_string( $_POST['post_id'] ),
-			// 'nonce2'	 => wp_create_nonce( 'bfc_post_unlike' ),
-		); // here like_users_string is for visible list of likers
-
-		// if ( ! bp_is_user() ) {
-		// 	$fav_count = (int) bfc_get_total_like_count_for_user( bp_loggedin_user_id() ); //bp_get_total_favorite_count_for_user buddyboss-platform/bp-activity/bp-activity-template.php line 3122
-
-		// 	if ( 1 === $fav_count ) {
-		// 		$response['directory_tab'] = '<li id="activity-favorites" data-bp-scope="favorites" data-bp-object="activity">
-		// 			<a href="' . bp_loggedin_user_domain() . bp_get_activity_slug() . '/favorites/">
-		// 				' . esc_html__( 'Likes', 'bfcommons-theme' ) . '
-		// 			</a>
-		// 		</li>';
-		// 	} else {
-		// 		$response['fav_count'] = $fav_count;
-		// 	}
-		// }
+		); 
 
 		wp_send_json_success( $response );
 	} else {
@@ -291,18 +265,7 @@ function bfc_ajax_unmark_post_like () { //bp_nouveau_ajax_unmark_activity_favori
 			'content'    => __( 'Like', 'bfcommons-theme' ),
 			'like_users_string' => bfc_like_users_string( $_POST['post_id'] ),
 			'tooltip'    => bfc_like_users_tooltip_string( $_POST['post_id'] ),
-			// 'nonce2'	 => wp_create_nonce( 'bfc_post_like' ),
-		); // here like_users_string is for visible list of likers.
-
-		// $fav_count = (int) bfc_get_total_like_count_for_user( bp_loggedin_user_id() );
-
-		// if ( 0 === $fav_count && ! bp_is_single_activity() ) { //todo
-		// 	$response['no_favorite'] = '<li><div class="bp-feedback bp-messages info">
-		// 		' . __( 'Sorry, there was no activity found.', 'bfcommons-theme' ) . '
-		// 	</div></li>';
-		// } else {
-		// 	$response['fav_count'] = $fav_count;
-		// }
+		); 
 
 		wp_send_json_success( $response );
 


### PR DESCRIPTION
There is a conflict between the bp_doc system and the BuddyBoss document system such that when a bp_doc system url is put into a forum post, BuddyBoss treats it as one of there documents and puts a special document attachment box at the end of the post. The fix here suppresses the conflict in the favor of the bp_doc system. If ever want to also use the BuddyBoss document system, a better integration will need to be found.