### PR TITLE
Fix for urls to doc folders

### DIFF
--- a/functions/bfc-editor.php
+++ b/functions/bfc-editor.php
@@ -131,7 +131,7 @@ add_filter( 'bbp_get_reply_content', 'bfc_fix_doc_url', 9999);
 add_filter( 'bbp_get_topic_content', 'bfc_fix_doc_url', 9999);
 
 function bfc_fix_doc_url( $content ){
-	$new_content = preg_replace('#href="https:.+?/docs/#', 'href="/docs/', $content);
+	$new_content = preg_replace('#href="https:.+?/docs/(\w+?)#', 'href="/docs/\1', $content);
 	return $new_content;
 }
 ?>


### PR DESCRIPTION
Only the links to docs need to be changed, not to folders. The new pattern skips ../docs/?folder=###.