### PR TITLE
Avoiding too long matches for doc url fix

### DIFF
--- a/functions/bfc-editor.php
+++ b/functions/bfc-editor.php
@@ -131,7 +131,7 @@ add_filter( 'bbp_get_reply_content', 'bfc_fix_doc_url', 9999);
 add_filter( 'bbp_get_topic_content', 'bfc_fix_doc_url', 9999);
 
 function bfc_fix_doc_url( $content ){
-	$new_content = preg_replace('#href="https:.+?/docs/(\w+?)#', 'href="/docs/\1', $content);
+	$new_content = preg_replace('#href="https:[^>]+?/docs/(\w+?)#', 'href="/docs/\1', $content);
 	return $new_content;
 }
 ?>


### PR DESCRIPTION
Should now work with multiple links to docs and folders all in the same paragraph.