### PR TITLE
Fix for Post submit button

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -2418,3 +2418,8 @@ body #buddypress .bp-list .action .generic-button .membership-requested:hover {
 	max-width: 880px;
 	margin: 0 auto;
 }
+
+#new-post .bbp-form #bbp_reply_submit {
+	opacity: 1;
+	pointer-events: initial;
+  }


### PR DESCRIPTION
A recent BuddyBoss update (I'm not sure which one) disabled the Post submit button on our forum posts. This is a quick css hack that re-enables it until there's a deeper fix.